### PR TITLE
Fixed NullPointerException on (invalid) numbering overrides.

### DIFF
--- a/src/main/java/org/docx4j/model/listnumbering/ListNumberingDefinition.java
+++ b/src/main/java/org/docx4j/model/listnumbering/ListNumberingDefinition.java
@@ -190,7 +190,7 @@ public class ListNumberingDefinition {
 						}
 
 						Lvl lvl = overrideNode.getLvl();
-						if (lvl != null) {
+						if (lvl != null && this.levels.get(overrideLevelId) != null) {
 							this.levels.get(overrideLevelId).SetOverrides(lvl);
 						}
 						


### PR DESCRIPTION
Fixed NullPointerException when (invalid) numbering overrides are set to override a non-existent level in a numbering definition.

I have a large scale app which has 55,000+ word docs that have been generated from a template which contained a numbering setup that tries to override non existent levels. The documents open and save fine in Word 2007+ however the PDF conversion sample fails with a NPE without the enclosed fix.

``` xml
<w:abstractNum w:abstractNumId="7">
  <w:nsid w:val="1BDE51C9"/>
  <w:multiLevelType w:val="multilevel"/>
  <w:tmpl w:val="F6023BA2"/>
  <w:numStyleLink w:val="LCPLList"/>
  <!-- no level definitions -->
</w:abstractNum>
```

``` xml
<w:num w:numId="18">
  <w:abstractNumId w:val="7"/>
  <w:lvlOverride w:ilvl="0">
    <w:lvl w:ilvl="0">
      <w:numFmt w:val="decimal"/>
      <w:lvlText w:val=""/>
      <w:lvlJc w:val="left"/>
    </w:lvl>
  </w:lvlOverride>
</w:num>
```
