### PR TITLE
Paragraph format is lost when the paragraph contains a MERGEFIELD.

### DIFF
--- a/src/main/java/org/docx4j/model/fields/FieldsPreprocessor.java
+++ b/src/main/java/org/docx4j/model/fields/FieldsPreprocessor.java
@@ -148,11 +148,11 @@ public class FieldsPreprocessor {
 						if (depth==1 ) { 
 						
 							// Add any content the run contains before the BEGIN
-							if (newR.getContent().size()>0) {
-								newP.getContent().add(newR);
-								
-								newR.setRPr(existingRun.getRPr() ); // if any
-							}
+//							if (newR.getContent().size()>0) {
+//								newP.getContent().add(newR);
+//
+//								newR.setRPr(existingRun.getRPr() ); // if any
+//							}
 
 							newR = Context.getWmlObjectFactory().createR();
 							newR.getContent().add(o2);
@@ -233,9 +233,11 @@ public class FieldsPreprocessor {
 						newR.setRPr(fieldRPr);
 						
 					} else {
-						newR.getContent().add(o2);													
-					}
-					
+						newR.getContent().add(o2);
+            newR.setRPr(existingRun.getRPr());
+            newP.getContent().add(newR);
+            newR = Context.getWmlObjectFactory().createR();
+          }
 				}
 				
 			} else {


### PR DESCRIPTION
When a document contains a paragraph that includes a MERGEFIELD instr element and a mail merge is performed with MailMerger.java, then the formatting of the rest of the text in this paragraph is not maintained.

The problem resides in the FieldsPreprocessor.canonicalise(...) implementation. I have already a workaround ready.
