### PR TITLE
XHTML importer produces incorrect files with vertically merged cells in tables

### DIFF
--- a/src/main/java/org/docx4j/convert/in/xhtml/XHTMLImporter.java
+++ b/src/main/java/org/docx4j/convert/in/xhtml/XHTMLImporter.java
@@ -671,7 +671,8 @@ public class XHTMLImporter {
             		            		
             		log.debug(".. processing <td");            		
             		// eg <td color: #000000; background-color: transparent; background-image: none; background-repeat: repeat; background-attachment: scroll; background-position: [0%, 0%]; background-size: [auto, auto]; border-collapse: collapse; -fs-border-spacing-horizontal: 0; -fs-border-spacing-vertical: 0; -fs-font-metric-src: none; -fs-keep-with-inline: auto; -fs-page-width: auto; -fs-page-height: auto; -fs-page-sequence: auto; -fs-pdf-font-embed: auto; -fs-pdf-font-encoding: Cp1252; -fs-page-orientation: auto; -fs-table-paginate: auto; -fs-text-decoration-extent: line; bottom: auto; caption-side: top; clear: none; ; content: normal; counter-increment: none; counter-reset: none; cursor: auto; ; display: table-row; empty-cells: show; float: none; font-style: normal; font-variant: normal; font-weight: normal; font-size: medium; line-height: normal; font-family: serif; -fs-table-cell-colspan: 1; -fs-table-cell-rowspan: 1; height: auto; left: auto; letter-spacing: normal; list-style-type: disc; list-style-position: outside; list-style-image: none; max-height: none; max-width: none; min-height: 0; min-width: 0; orphans: 2; ; ; ; overflow: visible; page: auto; page-break-after: auto; page-break-before: auto; page-break-inside: auto; position: static; ; right: auto; src: none; table-layout: auto; text-align: left; text-decoration: none; text-indent: 0; text-transform: none; top: auto; ; vertical-align: top; visibility: visible; white-space: normal; word-wrap: normal; widows: 2; width: auto; word-spacing: normal; z-index: auto; border-top-color: #000000; border-right-color: #000000; border-bottom-color: #000000; border-left-color: #000000; border-top-style: none; border-right-style: none; border-bottom-style: none; border-left-style: none; border-top-width: 2px; border-right-width: 2px; border-bottom-width: 2px; border-left-width: 2px; margin-top: 0; margin-right: 0; margin-bottom: 0; margin-left: 0; padding-top: 0; padding-right: 0; padding-bottom: 0; padding-left: 0;
-            		
+
+            		List<Object> trContext = contentContext;
             		org.docx4j.org.xhtmlrenderer.newtable.TableCellBox tcb = (org.docx4j.org.xhtmlrenderer.newtable.TableCellBox)box;
             		// tcb.getVerticalAlign()
             		
@@ -782,8 +783,8 @@ public class XHTMLImporter {
 						    	log.debug("it has rowspan  " + nextCell.getStyle().getRowSpan() );
 						    	// eg tcb is r2,c1 & nextCell is r1,c2
 								Tc dummy = Context.getWmlObjectFactory().createTc();
-								contentContext.add(dummy);
-	
+								trContext.add(dummy);
+
 								TcPr tcPr2 = Context.getWmlObjectFactory().createTcPr();
 								dummy.setTcPr(tcPr2);
 								

--- a/src/test/java/org/docx4j/convert/in/xhtml/XHTMLImporterTest.java
+++ b/src/test/java/org/docx4j/convert/in/xhtml/XHTMLImporterTest.java
@@ -1,0 +1,49 @@
+package org.docx4j.convert.in.xhtml;
+
+import org.docx4j.openpackaging.exceptions.Docx4JException;
+import org.docx4j.openpackaging.packages.WordprocessingMLPackage;
+import static org.junit.Assert.*;
+
+import org.docx4j.wml.Tbl;
+import org.docx4j.wml.Tc;
+import org.docx4j.wml.TcPrInner;
+import org.docx4j.wml.Tr;
+import org.junit.Test;
+
+import java.util.List;
+
+public class XHTMLImporterTest {
+
+	@Test public void testVerticalCellMerging() throws Docx4JException {
+
+		WordprocessingMLPackage wordMLPackage = WordprocessingMLPackage.createPackage();
+
+		String xhtml =
+			"<div><table>" +
+				"<tr><td>1</td><td rowspan='2'>2</td></tr>" +
+				"<tr><td>3</td></tr>" +
+			"</table></div>";
+		List<Object> converted = XHTMLImporter.convert(xhtml, "", wordMLPackage);
+
+		List<Object> tbl = ((Tbl) converted.get(1)).getContent();
+		assertEquals("table has two rows", tbl.size(), 2);
+
+		List<Object> tr1 = ((Tr) tbl.get(0)).getContent();
+		List<Object> tr2 = ((Tr) tbl.get(1)).getContent();
+		assertEquals("two cells in each row", tr1.size(), 2);
+		assertEquals("two cells in each row", tr2.size(), 2);
+
+		TcPrInner.VMerge vMerge1_1 = ((Tc) tr1.get(0)).getTcPr().getVMerge();
+		TcPrInner.VMerge vMerge2_1 = ((Tc) tr2.get(0)).getTcPr().getVMerge();
+		assertNull("no vMerge in first column", vMerge1_1);
+		assertNull("no vMerge in first column", vMerge2_1);
+
+		TcPrInner.VMerge vMerge1_2 = ((Tc) tr1.get(1)).getTcPr().getVMerge();
+		TcPrInner.VMerge vMerge2_2 = ((Tc) tr2.get(1)).getTcPr().getVMerge();
+		assertNotNull("vMerge exists in second column", vMerge1_2);
+		assertNotNull("vMerge exists in second column", vMerge2_2);
+
+		assertEquals("vMerge val is 'restart' in first row", vMerge1_2.getVal(), "restart");
+		assertNull("vMerge val is null in second row", vMerge2_2.getVal());
+	}
+}


### PR DESCRIPTION
Merged cell in all but first row are incorrectly placed inside previous cell.  Word refuses to open files with cells nested such way.
