### PR TITLE
Consider a VMerge value of "continue" when determining if a cell is a dummy

### DIFF
--- a/src/main/java/org/docx4j/model/table/Cell.java
+++ b/src/main/java/org/docx4j/model/table/Cell.java
@@ -107,7 +107,7 @@ public class Cell {
 		// rowspan
 		try {
 			String vm = tc.getTcPr().getVMerge().getVal();
-			if (vm == null)
+			if (vm == null || vm.equals("continue"))
 				dummy = true;
 			// dummy cells propagate this call upwards until a real cell is found
 			incrementRowSpan();


### PR DESCRIPTION
Cell objects only check for an empty value (which I've gathered is how Word implements it(?), but not LibreOffice) and not so if a table contains `<w:vMerge w:val="continue"/>` instead of `<w:vMerge/>`, `Cell.getExtraRows()` returns the wrong value.

This one line commit fixes that.
