### PR TITLE
Fixed several problems converting docx to pdf

### DIFF
--- a/src/main/java/org/docx4j/convert/out/common/writer/AbstractHyperlinkWriter.java
+++ b/src/main/java/org/docx4j/convert/out/common/writer/AbstractHyperlinkWriter.java
@@ -26,7 +26,6 @@ public abstract class AbstractHyperlinkWriter implements ModelConverter, Abstrac
 	HyperlinkModel hyperlinkModel = (HyperlinkModel)model;
 	Node ret = null;
 		ret = toNode(context, hyperlinkModel, doc);
-		XmlUtils.treeCopy(hyperlinkModel.getContent().getChildNodes(), ret);
 		return ret;
 	}
 


### PR DESCRIPTION
Fixes:
- removed treeCopy from AbstractHyperlinkWriter.java to prevent double
  links creation;
- added creation of TblPr to prevent NPE and moving of P created for
  <caption> tag in nestedTableHierarchyFix() method in XHTMLimporter.java.

So if one generates docx from html with table that has "caption" tag and then generates pdf from this docx,
everything will work.
