### PR TITLE
fixed code that generates TextId and ParaId

### DIFF
--- a/src/main/java/org/docx4j/openpackaging/parts/WordprocessingML/MainDocumentPartMceIgnorableHelper.java
+++ b/src/main/java/org/docx4j/openpackaging/parts/WordprocessingML/MainDocumentPartMceIgnorableHelper.java
@@ -92,7 +92,11 @@ public class MainDocumentPartMceIgnorableHelper {
 				
 				String uuid = java.util.UUID.randomUUID().toString();
 				// That's 32 digits, but 8'll do nicely
-				uuid = uuid.replace("-", "").substring(0, 8);
+				/*
+				* 8 can create a number too large - using 7
+				* Bob Fleischman - July 24, 2014
+				*/
+				uuid = uuid.replace("-", "").substring(0, 7);
 				
 				p.setParaId(uuid);
 				p.setTextId(uuid);


### PR DESCRIPTION
changed from 8 to 7 digits. It was generating numbers that exceeded the Microsoft documentation.
