### PR TITLE
bold/italic embedded font files with the same name in FontTable part 

### DIFF
--- a/src/main/java/org/docx4j/fonts/Mapper.java
+++ b/src/main/java/org/docx4j/fonts/Mapper.java
@@ -229,29 +229,41 @@ public abstract class Mapper {
 	}
 
 	public void registerBoldForm(String fontNameAsInFontTablePart, PhysicalFont pfBold) {
-		boldForms.put(fontNameAsInFontTablePart, pfBold);
+		if (pfBold == null) {
+			boldForms.remove(fontNameAsInFontTablePart);
+		} else {
+			boldForms.put(fontNameAsInFontTablePart, pfBold);
+		}
 	}
 
 	public void registerItalicForm(String fontNameAsInFontTablePart, PhysicalFont pfItalic) {
-		italicForms.put(fontNameAsInFontTablePart, pfItalic);
+		if (pfItalic == null) {
+			italicForms.remove(fontNameAsInFontTablePart);
+		} else {
+			italicForms.put(fontNameAsInFontTablePart, pfItalic);
+		}
 	}
 
 	public void registerBoldItalicForm(String fontNameAsInFontTablePart, PhysicalFont pfBoldItalic) {
-		boldItalicForms.put(fontNameAsInFontTablePart, pfBoldItalic);
+		if (pfBoldItalic == null) {
+			boldItalicForms.remove(fontNameAsInFontTablePart);
+		} else {
+			boldItalicForms.put(fontNameAsInFontTablePart, pfBoldItalic);
+		}
 	}
 
-	public PhysicalFont getBoldForm(PhysicalFont pf) {
-		final PhysicalFont pfBold = boldForms.get(pf.getName());
+	public PhysicalFont getBoldForm(String fontNameAsInFontTablePart, PhysicalFont pf) {
+		final PhysicalFont pfBold = boldForms.get(fontNameAsInFontTablePart);
 		return (pfBold != null) ? pfBold : PhysicalFonts.getBoldForm(pf);
 	}
 
-	public PhysicalFont getItalicForm(PhysicalFont pf) {
-		final PhysicalFont pfItalic = italicForms.get(pf.getName());
+	public PhysicalFont getItalicForm(String fontNameAsInFontTablePart, PhysicalFont pf) {
+		final PhysicalFont pfItalic = italicForms.get(fontNameAsInFontTablePart);
 		return (pfItalic != null) ? pfItalic : PhysicalFonts.getItalicForm(pf);
 	}
 
-	public PhysicalFont getBoldItalicForm(PhysicalFont pf) {
-		final PhysicalFont pfBoldItalic = boldItalicForms.get(pf.getName());
+	public PhysicalFont getBoldItalicForm(String fontNameAsInFontTablePart, PhysicalFont pf) {
+		final PhysicalFont pfBoldItalic = boldItalicForms.get(fontNameAsInFontTablePart);
 		return (pfBoldItalic != null) ? pfBoldItalic : PhysicalFonts.getBoldItalicForm(pf);
 	}
 }

--- a/src/main/java/org/docx4j/fonts/Mapper.java
+++ b/src/main/java/org/docx4j/fonts/Mapper.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,6 +63,10 @@ public abstract class Mapper {
 	
 	
 	protected static Logger log = LoggerFactory.getLogger(Mapper.class);
+
+	private ConcurrentHashMap<String, PhysicalFont> boldForms = new ConcurrentHashMap<String, PhysicalFont>();
+	private ConcurrentHashMap<String, PhysicalFont> italicForms = new ConcurrentHashMap<String, PhysicalFont>();
+	private ConcurrentHashMap<String, PhysicalFont> boldItalicForms = new ConcurrentHashMap<String, PhysicalFont>();
 
 	public Mapper() {
 		super();
@@ -222,5 +227,31 @@ public abstract class Mapper {
 		 */
 		
 	}
-	
+
+	public void registerBoldForm(String fontNameAsInFontTablePart, PhysicalFont pfBold) {
+		boldForms.put(fontNameAsInFontTablePart, pfBold);
+	}
+
+	public void registerItalicForm(String fontNameAsInFontTablePart, PhysicalFont pfItalic) {
+		italicForms.put(fontNameAsInFontTablePart, pfItalic);
+	}
+
+	public void registerBoldItalicForm(String fontNameAsInFontTablePart, PhysicalFont pfBoldItalic) {
+		boldItalicForms.put(fontNameAsInFontTablePart, pfBoldItalic);
+	}
+
+	public PhysicalFont getBoldForm(PhysicalFont pf) {
+		final PhysicalFont pfBold = boldForms.get(pf.getName());
+		return (pfBold != null) ? pfBold : PhysicalFonts.getBoldForm(pf);
+	}
+
+	public PhysicalFont getItalicForm(PhysicalFont pf) {
+		final PhysicalFont pfItalic = italicForms.get(pf.getName());
+		return (pfItalic != null) ? pfItalic : PhysicalFonts.getItalicForm(pf);
+	}
+
+	public PhysicalFont getBoldItalicForm(PhysicalFont pf) {
+		final PhysicalFont pfBoldItalic = boldItalicForms.get(pf.getName());
+		return (pfBoldItalic != null) ? pfBoldItalic : PhysicalFonts.getBoldItalicForm(pf);
+	}
 }

--- a/src/main/java/org/docx4j/fonts/PhysicalFonts.java
+++ b/src/main/java/org/docx4j/fonts/PhysicalFonts.java
@@ -2,10 +2,7 @@ package org.docx4j.fonts;
 
 import java.io.File;
 import java.net.URL;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.regex.Pattern;
 
 import org.slf4j.Logger;
@@ -227,7 +224,7 @@ public class PhysicalFonts {
 	 * 
 	 * @param fontUrl eg new java.net.URL("file:" + path)
 	 */
-	public static void addPhysicalFont(String nameAsInFontTablePart, URL fontUrl) {
+	public static List<PhysicalFont> addPhysicalFont(String nameAsInFontTablePart, URL fontUrl) {
 
 		
 		//List<EmbedFontInfo> embedFontInfoList = fontInfoFinder.find(fontUrl, fontResolver, fontCache);		
@@ -240,11 +237,11 @@ public class PhysicalFonts {
 			// Quite a few fonts exist that we can't seem to get
 			// EmbedFontInfo for. To be investigated.
 			log.warn("Aborting: " + fontUrl.toString() +  " (can't get EmbedFontInfo[] .. try deleting fop-fonts.cache?)");
-			return;
+			return null;
 		}
 		
 		StringBuffer debug = new StringBuffer();
-		
+		List<PhysicalFont> pfList = new ArrayList<PhysicalFont>();
 		for ( EmbedFontInfo fontInfo : embedFontInfoList ) {
 			
 			/* EmbedFontInfo has:
@@ -403,6 +400,7 @@ public class PhysicalFonts {
 		    	
 		        
 		        if (pf!=null) {
+							pfList.add(pf);
 		        	
 		        	// Add it to the map
 		        	put(pf.getName(), pf);
@@ -446,6 +444,7 @@ public class PhysicalFonts {
 			}            	
 		
 		log.debug(debug.toString() );
+		return pfList;
 	}
 	
 	public static PhysicalFont getBoldForm( PhysicalFont pf) {

--- a/src/main/java/org/docx4j/fonts/fop/util/FopConfigUtil.java
+++ b/src/main/java/org/docx4j/fonts/fop/util/FopConfigUtil.java
@@ -133,7 +133,7 @@ public class FopConfigUtil {
 		    result.append("</font>" );
 		    
 		    // bold, italic etc
-		    PhysicalFont pfVariation = fontMapper.getBoldForm(pf);
+		    PhysicalFont pfVariation = fontMapper.getBoldForm(fontName, pf);
 		    if (pfVariation==null) {
 		    	log.debug(fontName + " no bold form");
 		    } else {
@@ -141,7 +141,7 @@ public class FopConfigUtil {
 		    	addFontTriplet(result, pf.getName(), "normal", "bold");
 			    result.append("</font>" );
 		    }
-		    pfVariation = fontMapper.getBoldItalicForm(pf);
+		    pfVariation = fontMapper.getBoldItalicForm(fontName, pf);
 		    if (pfVariation==null) {
 		    	log.debug(fontName + " no bold italic form");
 		    } else {
@@ -149,7 +149,7 @@ public class FopConfigUtil {
 		    	addFontTriplet(result, pf.getName(), "italic", "bold");
 			    result.append("</font>" );
 		    }
-		    pfVariation = fontMapper.getItalicForm(pf);
+		    pfVariation = fontMapper.getItalicForm(fontName, pf);
 		    if (pfVariation==null) {
 		    	log.debug(fontName + " no italic form");
 		    } else {

--- a/src/main/java/org/docx4j/fonts/fop/util/FopConfigUtil.java
+++ b/src/main/java/org/docx4j/fonts/fop/util/FopConfigUtil.java
@@ -133,7 +133,7 @@ public class FopConfigUtil {
 		    result.append("</font>" );
 		    
 		    // bold, italic etc
-		    PhysicalFont pfVariation = PhysicalFonts.getBoldForm(pf);
+		    PhysicalFont pfVariation = fontMapper.getBoldForm(pf);
 		    if (pfVariation==null) {
 		    	log.debug(fontName + " no bold form");
 		    } else {
@@ -141,7 +141,7 @@ public class FopConfigUtil {
 		    	addFontTriplet(result, pf.getName(), "normal", "bold");
 			    result.append("</font>" );
 		    }
-		    pfVariation = PhysicalFonts.getBoldItalicForm(pf);
+		    pfVariation = fontMapper.getBoldItalicForm(pf);
 		    if (pfVariation==null) {
 		    	log.debug(fontName + " no bold italic form");
 		    } else {
@@ -149,7 +149,7 @@ public class FopConfigUtil {
 		    	addFontTriplet(result, pf.getName(), "italic", "bold");
 			    result.append("</font>" );
 		    }
-		    pfVariation = PhysicalFonts.getItalicForm(pf);
+		    pfVariation = fontMapper.getItalicForm(pf);
 		    if (pfVariation==null) {
 		    	log.debug(fontName + " no italic form");
 		    } else {

--- a/src/main/java/org/docx4j/openpackaging/packages/WordprocessingMLPackage.java
+++ b/src/main/java/org/docx4j/openpackaging/packages/WordprocessingMLPackage.java
@@ -330,7 +330,7 @@ public class WordprocessingMLPackage extends OpcPackage {
 				log.warn("FontTable missing; creating default part.");
 				fontTablePart= new org.docx4j.openpackaging.parts.WordprocessingML.FontTablePart();
 				fontTablePart.unmarshalDefaultFonts();
-				fontTablePart.processEmbeddings();
+				fontTablePart.processEmbeddings(fontMapper);
 			}
 			
 			fonts = (org.docx4j.wml.Fonts)fontTablePart.getJaxbElement();

--- a/src/main/java/org/docx4j/openpackaging/parts/WordprocessingML/FontTablePart.java
+++ b/src/main/java/org/docx4j/openpackaging/parts/WordprocessingML/FontTablePart.java
@@ -108,6 +108,7 @@ public final class FontTablePart extends JaxbXmlPart<Fonts> {
 			PhysicalFont pfBold = getObfuscatedFontFromRelationship(fontName, fontName + "-bold", embedBold);
 			PhysicalFont pfItalic = getObfuscatedFontFromRelationship(fontName, fontName + "-italic", embedItalic);
 			PhysicalFont pfBoldItalic = getObfuscatedFontFromRelationship(fontName, fontName + "-bold-italic", embedBoldItalic);
+			if (fontMapper != null && pfRegular != null) {
 				fontMapper.registerBoldForm(fontName, pfBold);
 				fontMapper.registerItalicForm(fontName, pfItalic);
 				fontMapper.registerBoldItalicForm(fontName, pfBoldItalic);

--- a/src/main/java/org/docx4j/openpackaging/parts/WordprocessingML/ObfuscatedFontPart.java
+++ b/src/main/java/org/docx4j/openpackaging/parts/WordprocessingML/ObfuscatedFontPart.java
@@ -23,9 +23,11 @@ package org.docx4j.openpackaging.parts.WordprocessingML;
 import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.util.List;
 
 import org.docx4j.Docx4jProperties;
 import org.docx4j.fonts.PhysicalFont;
+import org.docx4j.fonts.PhysicalFonts;
 import org.docx4j.fonts.fop.fonts.CustomFont;
 import org.docx4j.fonts.fop.fonts.EncodingMode;
 import org.docx4j.fonts.fop.fonts.FontLoader;
@@ -209,8 +211,8 @@ public class ObfuscatedFontPart extends BinaryPart {
 
 		// Add this font to our known physical fonts  
         try {
-					org.docx4j.fonts.PhysicalFonts.addPhysicalFont(fontNameAsInTablePart, new java.net.URL("file:" + path) );
-					return org.docx4j.fonts.PhysicalFonts.get(fontNameAsInTablePart);
+					List<PhysicalFont> fonts = PhysicalFonts.addPhysicalFont(fontNameAsInTablePart, new java.net.URL("file:" + path));
+					return (fonts == null || fonts.isEmpty()) ? null : fonts.iterator().next();
 
 
 			// This needs to be done before populateFontMappings, 

--- a/src/main/java/org/docx4j/openpackaging/parts/WordprocessingML/ObfuscatedFontPart.java
+++ b/src/main/java/org/docx4j/openpackaging/parts/WordprocessingML/ObfuscatedFontPart.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 
 import org.docx4j.Docx4jProperties;
+import org.docx4j.fonts.PhysicalFont;
 import org.docx4j.fonts.fop.fonts.CustomFont;
 import org.docx4j.fonts.fop.fonts.EncodingMode;
 import org.docx4j.fonts.fop.fonts.FontLoader;
@@ -120,12 +121,12 @@ public class ObfuscatedFontPart extends BinaryPart {
 	/**
 	 * deObfuscate this font, and save it using fontName
 	 * 
-	 * @param fontName - the name to save the font as. We
+	 * @param fontNameAsInTablePart - the name to save the font as. We
 	 * could read the font name from the deObfuscated data,
 	 * but FontLoader can't readily load from a byte array. 
 	 * @param fontKey
 	 */
-	public void deObfuscate(String fontName, String fontKey ) {
+	public PhysicalFont deObfuscate(String fontNameAsInTablePart, String fontFileName, String fontKey ) {
 		
 		byte[] fontData = this.getBytes();
 		
@@ -163,7 +164,7 @@ public class ObfuscatedFontPart extends BinaryPart {
 		}
 		
 		// Save the result
-		java.io.File f = new File(tmpFontDir, fontName +".ttf"); 
+		java.io.File f = new File(tmpFontDir, fontFileName +".ttf");
 		String path = null; 
 		
 		java.io.FileOutputStream fos = null; 
@@ -205,11 +206,13 @@ public class ObfuscatedFontPart extends BinaryPart {
 	        	}
 	        }
 		}
-		
+
 		// Add this font to our known physical fonts  
         try {
-			org.docx4j.fonts.PhysicalFonts.addPhysicalFont(fontName, new java.net.URL("file:" + path) );
-			
+					org.docx4j.fonts.PhysicalFonts.addPhysicalFont(fontNameAsInTablePart, new java.net.URL("file:" + path) );
+					return org.docx4j.fonts.PhysicalFonts.get(fontNameAsInTablePart);
+
+
 			// This needs to be done before populateFontMappings, 
 			// otherwise this font will be ignored, and references
 			// to it mapped to some substitute font!
@@ -218,6 +221,7 @@ public class ObfuscatedFontPart extends BinaryPart {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
+		return null;
 		
 	}
 	


### PR DESCRIPTION
When FontTable part has font name="ABC" and 1 embedded font file for
regular and another for bold we have to 1. use different file names when
saving them in /temporary embedded files/ storage (was saving ABC.ttf as
regular and then overwriting it as ABC.ttf with bold) 2. register them
as bold/italic/bold+italic in a document's FontMapper so that they can
be accessed by FOP later (was: ignoring embedded bold/italic/bold+italic
fonts as there were no mapping for them in
PhysicalFonts.getBoldForm=>MicrosoftFontsRegistry