### PR TITLE
Explicitly checking debug log level when printing DOM as string

### DIFF
--- a/src/main/java/org/docx4j/XmlUtils.java
+++ b/src/main/java/org/docx4j/XmlUtils.java
@@ -1131,7 +1131,9 @@ public class XmlUtils {
 
     public static List<Node> xpath(Node node, String xpathExpression, NamespaceContext nsContext) {
     	
-        log.debug(w3CDomNodeToString(node));
+    	if (log.isDebugEnabled()) {
+        	log.debug(w3CDomNodeToString(node));
+    	}
         
         // create XPath
         XPath xpath = XPathFactoryUtil.newXPath();


### PR DESCRIPTION
![2015-07-18 17_25_59-structures-webapp no packaging - 8 - no dcevm - yourkit java profiler 2015 bui](https://cloud.githubusercontent.com/assets/903037/8761981/2c155784-2d74-11e5-8dc8-2dde12056598.png)
