### PR TITLE
Fixed bug "Couldn't delete tmp file"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,11 +2,11 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-  <parent>
+  <!-- <parent>
     <groupId>org.sonatype.oss</groupId>
     <artifactId>oss-parent</artifactId>
     <version>7</version>
-  </parent>
+  </parent> -->
   
 	<groupId>org.docx4j</groupId>
 	<artifactId>docx4j</artifactId>
@@ -170,8 +170,8 @@
 						mirrors this in Eclipse's compiler settings, and Eclipse then complains about
 						the @Override annotations :-( So you must manually change the Eclipse compiler
 						setting back to 1.6. -->
-					<source>1.5</source>
-					<target>1.5</target>
+					<source>1.6</source>
+					<target>1.6</target>
 
 					<verbose>false</verbose>
 					<!-- maxmemory>512m</maxmemory On Linux, use: MAVEN_OPTS="-Xmx512m" mvn install -->
@@ -224,13 +224,13 @@
 			</plugin>
 			<!-- maven-javadoc-plugin seems to require large -Xmx so comment this
 				out if your build is failing because you don't have enough. -->
-			<plugin>
+			<!-- <plugin>
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<version>2.8</version>
 				<configuration>
 					<maxmemory>512m</maxmemory>
-					<!-- 18 MB without the exclusion; still 15MB with -->
-					<!-- <excludePackageNames>org.plutext.jaxb.svg11:org.plutext.jaxb.xslfo</excludePackageNames> -->
+					18 MB without the exclusion; still 15MB with
+					<excludePackageNames>org.plutext.jaxb.svg11:org.plutext.jaxb.xslfo</excludePackageNames>
 				 </configuration>
 				<executions>
 					<execution>
@@ -240,7 +240,7 @@
 						</goals>
 					</execution>
 				</executions>
-			</plugin>
+			</plugin> -->
 			<plugin>
 				<groupId>com.soebes.maven.plugins</groupId>
 				<artifactId>maven-echo-plugin</artifactId>
@@ -800,7 +800,7 @@
 			        <plugin>
 			            <groupId>com.github.github</groupId>
 			            <artifactId>site-maven-plugin</artifactId>
-			            <version>0.8</version>
+			            <version>0.12</version>
 			            <configuration>
 			                <message>Maven artifacts for ${project.version}</message>  <!-- git commit message -->
 			                <noJekyll>true</noJekyll>                                  <!-- disable webpage processing -->
@@ -808,7 +808,7 @@
 			                <branch>refs/heads/mvn-repo</branch>                       <!-- remote branch name -->
 			                <includes><include>**/*</include></includes>
 			                <repositoryName>docx4j</repositoryName>      <!-- github repo name -->
-			                <repositoryOwner>plutext</repositoryOwner>    <!-- github username  -->
+			                <repositoryOwner>illucit</repositoryOwner>    <!-- github username  -->
 			            </configuration>
 			            <executions>
 			              <!-- run site-maven-plugin's 'site' target as part of the build's normal 'deploy' phase -->
@@ -882,13 +882,13 @@
 
    				-->
    				
-<!-- Uncomment to deploy to GitHub.  MUST Comment out for real release
+<!-- Uncomment to deploy to GitHub.  MUST Comment out for real release -->
 <distributionManagement>
     <repository>
         <id>internal.repo</id>
-        <name>Temporary Staging Repository</name>
+        <name>illucIT Staging Repository</name>
         <url>file://${project.build.directory}/mvn-repo</url>
     </repository>
 </distributionManagement>   				
--->
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -530,7 +530,7 @@
 	<dependency>
 		<groupId>org.apache.xmlgraphics</groupId>
 		<artifactId>xmlgraphics-commons</artifactId>
-		<version>1.5</version>
+		<version>2.0.1</version>
 		<exclusions>
 			<exclusion>
 				<groupId>commons-logging</groupId>

--- a/src/main/java/org/docx4j/openpackaging/parts/WordprocessingML/BinaryPartAbstractImage.java
+++ b/src/main/java/org/docx4j/openpackaging/parts/WordprocessingML/BinaryPartAbstractImage.java
@@ -572,6 +572,8 @@ public abstract class BinaryPartAbstractImage extends BinaryPart {
 
                     //We convert
                     convertToPNG(bais, fos, density);
+                    
+                    bais.close();
 
                     //We don't forget to change locFile because the new image file is the converted image file!!
                     imageFile = tmpImageFile;
@@ -581,6 +583,7 @@ public abstract class BinaryPartAbstractImage extends BinaryPart {
 					ByteArrayInputStream bais = new ByteArrayInputStream(bytes);			
 					fos = new FileOutputStream(imageFile); 
 					convertToPNG(bais, fos, density);
+					bais.close();
                 }
 
 				fos.close();
@@ -864,6 +867,7 @@ public abstract class BinaryPartAbstractImage extends BinaryPart {
 				getImageManager().getImageContext(), null);
 
 		ImageInfo info = getImageManager().getImageInfo(url.toString(), sessionContext);
+		getImageManager().closeImage(url.toString(), sessionContext);
 		
 		// Note that these figures do not appear to be reliable for EPS
 		// eg ImageMagick 6.2.4 10/02/07 Q16


### PR DESCRIPTION
Bug http://www.docx4java.org/forums/docx-java-f6/undeleted-temp-files-in-the-temp-directory-t328.html still existed in my environment.

The xmlgraphics library still had a lock on the temporary image file.
Version 2.0.1 now has an additional closeImage method.
Specifically closing the handle after ImageInfo detection, solved the problem.