### PR TITLE
Improve performance by skipping expensive conversions to string when not logging

### DIFF
--- a/docx4j.iml
+++ b/docx4j.iml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_5" inherit-compiler-output="false">
+    <output url="file://$MODULE_DIR$/bin" />
+    <output-test url="file://$MODULE_DIR$/bin-testOutput" />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/pptx4j/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/xlsx4j/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/glox4j/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/diffx" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
+      <excludeFolder url="file://$MODULE_DIR$/bin" />
+      <excludeFolder url="file://$MODULE_DIR$/bin-testOutput" />
+      <excludeFolder url="file://$MODULE_DIR$/target" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="Maven: org.plutext:jaxb-svg11:1.0.2" level="project" />
+    <orderEntry type="library" name="Maven: org.plutext:jaxb-xslfo:1.0.1" level="project" />
+    <orderEntry type="library" name="Maven: org.plutext:jaxb-xmldsig-core:1.0.0" level="project" />
+    <orderEntry type="library" name="Maven: net.engio:mbassador:1.1.10" level="project" />
+    <orderEntry type="library" name="Maven: org.slf4j:slf4j-api:1.7.5" level="project" />
+    <orderEntry type="library" name="Maven: org.slf4j:jcl-over-slf4j:1.7.5" level="project" />
+    <orderEntry type="library" name="Maven: org.slf4j:slf4j-log4j12:1.7.5" level="project" />
+    <orderEntry type="library" name="Maven: log4j:log4j:1.2.17" level="project" />
+    <orderEntry type="library" name="Maven: commons-lang:commons-lang:2.4" level="project" />
+    <orderEntry type="library" name="Maven: commons-codec:commons-codec:1.10" level="project" />
+    <orderEntry type="library" name="Maven: commons-io:commons-io:1.3.1" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.xmlgraphics:xmlgraphics-commons:1.5" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.xmlgraphics:fop:1.1" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.xmlgraphics:batik-svg-dom:1.7" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.xmlgraphics:batik-anim:1.7" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.xmlgraphics:batik-awt-util:1.7" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.xmlgraphics:batik-util:1.7" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.xmlgraphics:batik-dom:1.7" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.xmlgraphics:batik-css:1.7" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.xmlgraphics:batik-ext:1.7" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.xmlgraphics:batik-xml:1.7" level="project" />
+    <orderEntry type="library" name="Maven: xalan:xalan:2.7.1" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.xmlgraphics:batik-parser:1.7" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.xmlgraphics:batik-bridge:1.7" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.xmlgraphics:batik-gvt:1.7" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.xmlgraphics:batik-script:1.7" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.xmlgraphics:batik-transcoder:1.7" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.xmlgraphics:batik-svggen:1.7" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.xmlgraphics:batik-extension:1.7" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.avalon.framework:avalon-framework-api:4.3.1" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.avalon.framework:avalon-framework-impl:4.3.1" level="project" />
+    <orderEntry type="library" name="Maven: xalan:serializer:2.7.1" level="project" />
+    <orderEntry type="library" name="Maven: net.arnx:wmf2svg:0.9.0" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.poi:poi-scratchpad:3.8" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.poi:poi:3.8" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: com.googlecode.jaxb-namespaceprefixmapper-interfaces:JAXBNamespacePrefixMapper:2.2.4" level="project" />
+    <orderEntry type="library" name="Maven: org.antlr:antlr-runtime:3.3" level="project" />
+    <orderEntry type="library" name="Maven: org.antlr:stringtemplate:3.2.1" level="project" />
+    <orderEntry type="library" name="Maven: antlr:antlr:2.7.7" level="project" />
+    <orderEntry type="library" name="Maven: com.google.guava:guava:17.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: junit:junit:4.8" level="project" />
+  </component>
+</module>
+

--- a/src/docx4j-extras/PdfViaIText/org/docx4j/convert/out/pdf/viaIText/Conversion.java
+++ b/src/docx4j-extras/PdfViaIText/org/docx4j/convert/out/pdf/viaIText/Conversion.java
@@ -258,7 +258,9 @@ public class Conversion extends org.docx4j.convert.out.pdf.PdfConversion {
 						}
 						
 						if (documentFont==null) {
-							log.error("Font was null in: " + XmlUtils.marshaltoString(rPr, true, true));
+                            if(log.isErrorEnabled() {
+                                log.error("Font was null in: " + XmlUtils.marshaltoString(rPr, true, true));
+                            }
 							documentFont=Mapper.FONT_FALLBACK;
 						}
 						

--- a/src/main/java/org/docx4j/convert/out/common/AbstractVisitorExporterGenerator.java
+++ b/src/main/java/org/docx4j/convert/out/common/AbstractVisitorExporterGenerator.java
@@ -19,9 +19,6 @@
  */
 package org.docx4j.convert.out.common;
 
-import java.util.LinkedList;
-import java.util.List;
-
 import org.docx4j.TraversalUtil;
 import org.docx4j.XmlUtils;
 import org.docx4j.convert.out.common.writer.AbstractBookmarkStartWriter;
@@ -45,6 +42,9 @@ import org.w3c.dom.Document;
 import org.w3c.dom.DocumentFragment;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
+
+import java.util.LinkedList;
+import java.util.List;
 
 /**
  * The …ExporterGenerator is the visitor, that gets used in those cases where a document is done 
@@ -391,8 +391,10 @@ public abstract class AbstractVisitorExporterGenerator<CC extends AbstractWmlCon
 		//CTMarkupRange is the w:bookmarkEnd
 			
 		} else {
-			log.warn("Need to handle " + o.getClass().getName() );	
-			log.debug(XmlUtils.marshaltoString(o));
+			log.warn("Need to handle " + o.getClass().getName() );
+            if(log.isDebugEnabled()) {
+                log.debug(XmlUtils.marshaltoString(o));
+            }
 		}
 		
 		return null;

--- a/src/main/java/org/docx4j/convert/out/common/preprocess/ParagraphStylesInTableFix.java
+++ b/src/main/java/org/docx4j/convert/out/common/preprocess/ParagraphStylesInTableFix.java
@@ -19,14 +19,6 @@
  */
 package org.docx4j.convert.out.common.preprocess;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 import org.docx4j.TraversalUtil;
 import org.docx4j.TraversalUtil.CallbackImpl;
 import org.docx4j.XmlUtils;
@@ -52,6 +44,14 @@ import org.docx4j.wml.TblPr;
 import org.jvnet.jaxb2_commons.ppp.Child;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 
 
@@ -281,8 +281,10 @@ public class ParagraphStylesInTableFix {
 					tableStyle = defaultTableStyle.getStyleId();
 					// shouldn't happen, but just in case..
 					if (tableStyle==null) {
-						log.error("Default table style has no ID!"); 
-						log.error(XmlUtils.marshaltoString(tableStyle));
+                        if(log.isErrorEnabled()) {
+                            log.error("Default table style has no ID!");
+                            log.error(XmlUtils.marshaltoString(tableStyle));
+                        }
 						return null;						
 					}
 				}
@@ -318,11 +320,15 @@ public class ParagraphStylesInTableFix {
 			
 			// First, docDefaults
 			Style styleToApply = hierarchy.get(hierarchy.size()-1); // DocDefault
-			log.debug("DocDefault");
-			log.debug(XmlUtils.marshaltoString(styleToApply, true, true));
+            if(log.isDebugEnabled()) {
+                log.debug("DocDefault");
+                log.debug(XmlUtils.marshaltoString(styleToApply, true, true));
+            }
 			StyleUtil.apply(styleToApply, newStyle);
-			log.debug("Result");
-			log.debug(XmlUtils.marshaltoString(newStyle, true, true));
+            if(log.isDebugEnabled()) {
+                log.debug("Result");
+                log.debug(XmlUtils.marshaltoString(newStyle, true, true));
+            }
 			
 			// Next, table style - first/temporarily in tableStyleContrib
 			Style tableStyleContrib = null;
@@ -359,10 +365,15 @@ public class ParagraphStylesInTableFix {
 
 	    		for (int i = tblStyles.size()-1; i>=0; i--) {
 	    			styleToApply = tblStyles.get(i);
-	    			log.debug("Applying " + styleToApply.getStyleId() + "\n" + XmlUtils.marshaltoString(styleToApply, true, true));
+                    if(log.isDebugEnabled()) {
+                        log.debug("Applying " + styleToApply.getStyleId() + "\n" + XmlUtils.marshaltoString(styleToApply, true, true));
+
+                    }
 	    			
 	    			tableStyleContrib = StyleUtil.apply(styleToApply, tableStyleContrib);
-	    			log.debug(XmlUtils.marshaltoString(tableStyleContrib, true, true));
+                    if(log.isDebugEnabled()) {
+                        log.debug(XmlUtils.marshaltoString(tableStyleContrib, true, true));
+                    }
 	    		}
 			}
 			
@@ -384,17 +395,23 @@ public class ParagraphStylesInTableFix {
 			// As these are different style types:-
 			newStyle.setPPr(StyleUtil.apply(tableStyleContrib.getPPr(), newStyle.getPPr()));
 			newStyle.setRPr(StyleUtil.apply(tableStyleContrib.getRPr(), newStyle.getRPr()));
-			log.debug(XmlUtils.marshaltoString(newStyle, true, true));
+            if(log.isDebugEnabled()) {
+                log.debug(XmlUtils.marshaltoString(newStyle, true, true));
+            }
 			
 			
 			// Finally, rest of list in reverse
 			for (int i = hierarchy.size()-2; i>=0; i--) {
 				styleToApply = hierarchy.get(i);
-				log.debug("Applying " + styleToApply.getStyleId() +
-						"\n" + XmlUtils.marshaltoString(styleToApply, true, true));
+                if(log.isDebugEnabled()) {
+                    log.debug("Applying " + styleToApply.getStyleId() +
+                            "\n" + XmlUtils.marshaltoString(styleToApply, true, true));
+                }
 				StyleUtil.apply(styleToApply, newStyle);
-				log.debug("Result: " + 
-						"\n" + XmlUtils.marshaltoString(newStyle, true, true));
+                if(log.isDebugEnabled()) {
+                    log.debug("Result: " +
+                            "\n" + XmlUtils.marshaltoString(newStyle, true, true));
+                }
 			}
 			
 		    /*
@@ -494,7 +511,9 @@ public class ParagraphStylesInTableFix {
 			// required for PDF (but not XHTML) output
 			propertyResolver.activateStyle(newStyle);
 
-			log.debug(XmlUtils.marshaltoString(newStyle, true, true));
+            if(log.isDebugEnabled()) {
+                log.debug(XmlUtils.marshaltoString(newStyle, true, true));
+            }
 			
 			return resultStyleID;
 		}

--- a/src/main/java/org/docx4j/convert/out/common/writer/AbstractTableWriterModelCell.java
+++ b/src/main/java/org/docx4j/convert/out/common/writer/AbstractTableWriterModelCell.java
@@ -94,10 +94,14 @@ public class AbstractTableWriterModelCell {
 		tcPr = tc.getTcPr();
 
 		if (content==null) {
-			logger.error("No content for row " + row + ", col " + col + "\n" 
-							+ XmlUtils.marshaltoString(tc, true, true));
+            if(logger.isErrorEnabled()) {
+                logger.error("No content for row " + row + ", col " + col + "\n"
+                        + XmlUtils.marshaltoString(tc, true, true));
+            }
 		} else {
-			logger.debug("Cell content: " + XmlUtils.w3CDomNodeToString(content));
+            if(logger.isDebugEnabled()) {
+                logger.debug("Cell content: " + XmlUtils.w3CDomNodeToString(content));
+            }
 		}
 
 		/* xhtmlTc.appendChild(

--- a/src/main/java/org/docx4j/convert/out/fo/FOPictWriterAbstract.java
+++ b/src/main/java/org/docx4j/convert/out/fo/FOPictWriterAbstract.java
@@ -44,32 +44,32 @@ import org.w3c.dom.NodeList;
 
 /**
  * Note that despite its name, this currently only handles v:textbox.
- * 
+ *
  * Images (ie ./v:shape/v:imagedata) are handled differently, by legacy code.
- * 
- * 
+ *
+ *
  * @author jharrop
  *
  */
 public abstract class FOPictWriterAbstract extends AbstractPictWriter {
-	
+
 	protected static Logger log = LoggerFactory.getLogger(FOPictWriterAbstract.class);
-	
+
 	private static String XSL_FO = "http://www.w3.org/1999/XSL/Format";
-	
+
 	public FOPictWriterAbstract() {
 		super();
 	}
-	
+
 	public abstract boolean foRendererSupportsFoFloat();
-	
+
 	@Override
-	public Node toNode(AbstractWmlConversionContext context, Object unmarshalledNode, 
+	public Node toNode(AbstractWmlConversionContext context, Object unmarshalledNode,
 			Node modelContent, TransformState state, Document doc)
 			throws TransformerException {
 
 		org.docx4j.wml.Pict pict = (org.docx4j.wml.Pict)unmarshalledNode;
-		
+
 		/*
             <w:pict>
               <v:shapetype id="_x0000_t202" coordsize="21600,21600" o:spt="202" path="m,l,21600r21600,l21600,xe">
@@ -95,7 +95,7 @@ public abstract class FOPictWriterAbstract extends AbstractPictWriter {
 		// Get the shape or rectangle...
 		org.docx4j.vml.VmlShapeElements shape = null;
 		for (Object o : pict.getAnyAndAny() ) {
-			
+
 			o = XmlUtils.unwrap(o);
 //			System.out.println(o.getClass().getName());
 			if (o instanceof org.docx4j.vml.VmlShapeElements
@@ -106,16 +106,16 @@ public abstract class FOPictWriterAbstract extends AbstractPictWriter {
 			}
 		}
 		if (shape==null) {
-			return context.getMessageWriter().message(context, 
+			return context.getMessageWriter().message(context,
 					"Couldn't find v:shape (or v:rectangle etc) in w:pict.");
 		}
 
 		org.docx4j.vml.CTTextbox textBox = null;
-		org.docx4j.vml.wordprocessingDrawing.CTWrap w10Wrap = null;  
+		org.docx4j.vml.wordprocessingDrawing.CTWrap w10Wrap = null;
 		for (Object o : shape.getEGShapeElements() ) {
-			
+
 			o = XmlUtils.unwrap(o);
-			
+
 			if (o instanceof org.docx4j.vml.CTTextbox) {
 				textBox = (org.docx4j.vml.CTTextbox)o;
 			}
@@ -124,108 +124,110 @@ public abstract class FOPictWriterAbstract extends AbstractPictWriter {
 			}
 		}
 		if (textBox==null) {
-			return context.getMessageWriter().message(context, 
+			return context.getMessageWriter().message(context,
 					"Couldn't find v:textbox in w:shape.");
 		}
-		
-		
+
+
 
 		Map<String, String> props = null;
 		if (shape instanceof VmlAllCoreAttributes) {
-			props = getProperties(((VmlAllCoreAttributes)shape).getStyle()); 
+			props = getProperties(((VmlAllCoreAttributes)shape).getStyle());
 		} else {
 			log.warn(shape.getClass().getName() + " does not implement VmlAllCoreAttributes, so can't access @style if present");
-			return context.getMessageWriter().message(context, 
+			return context.getMessageWriter().message(context,
 					shape.getClass().getName() + " does not implement VmlAllCoreAttributes, so can't access @style if present");
 		}
-		
-		
+
+
 //		// temp
 //		if (props.size()==0) {
 //			System.out.println(XmlUtils.marshaltoString(pict));
 //		}
-		
-		
+
+
 		boolean wrap = true;
 		if (w10Wrap!=null) {
-			
+
 			if (w10Wrap.getType()!=null
 					&& (w10Wrap.getType().equals(STWrapType.TOP_AND_BOTTOM)
 					|| w10Wrap.getType().equals(STWrapType.SQUARE)
 					|| w10Wrap.getType().equals(STWrapType.TIGHT)
 					|| w10Wrap.getType().equals(STWrapType.THROUGH))) {
-				
+
 				wrap = false;
 			}
-			
+
 			// the no wrap page top case
 			if (w10Wrap.getAnchory()!=null
 					&& (w10Wrap.getAnchory().equals(STVerticalAnchor.PAGE)  )) {
-				
+
 				wrap = false;
-			} 
-			
+			}
+
 		}
-			
+
 		return handleVTextBox(context, modelContent, doc, shape, props, wrap);
 	}
 
-	
-	
+
+
 	public Node handleVTextBox(AbstractWmlConversionContext context,
-			Node modelContent, Document doc, 
+			Node modelContent, Document doc,
 			org.docx4j.vml.VmlShapeElements shape,
-			Map<String, String> props, 
+			Map<String, String> props,
 			boolean wrap) {
-	
+
 		String mso_position_vertical_relative = props.get("mso-position-vertical-relative");
 		String mso_position_vertical = props.get("mso-position-vertical");
 //		String z_index = props.get("z_index"); // negative -> behind
 //
-		
+
 //		String width = props.get("width");
 //		String height = props.get("height");
 
-		
+
 		// How to get current page width??
 		ConversionSectionWrapper csw = context.getSections().getCurrentSection();
 		PageDimensions pageDimensions = csw.getPageDimensions();
-		
+
 		// pgSz.getW().intValue() - (pgMar.getLeft().intValue() + pgMar.getRight().intValue());
 		int writableWidthTwips = pageDimensions.getWritableWidthTwips();
 		float writableWidthPts = writableWidthTwips/20;
 		int writableHeightTwips = pageDimensions.getWritableHeightTwips();
 		float writableHeightPts = writableHeightTwips/20;
 
-		// TODO - avoid reference to FORenderer here! See  
+		// TODO - avoid reference to FORenderer here! See
 		FORenderer foRenderer  = ((FOSettings)context.getConversionSettings()).getCustomFoRenderer();
 		log.debug(foRenderer.getClass().getName());
-		
-		
+
+
 		if (wrap) {
 			// Floats define a block that is "out of line" in drifts to the top/left/right side of the page;
 			// the text *flows around it*.
-			
+
 			log.debug("textbox - wrapped text");
 
 			if (mso_position_vertical_relative==null) {
-				
-				try {
-					log.warn(XmlUtils.marshaltoString(shape));
-				} catch (Exception e) {
-					log.warn(e.getMessage());
-				}
-				return context.getMessageWriter().message(context, 
+
+                if(log.isWarnEnabled()) {
+                    try {
+                        log.warn(XmlUtils.marshaltoString(shape));
+                    } catch (Exception e) {
+                        log.warn(e.getMessage());
+                    }
+                }
+				return context.getMessageWriter().message(context,
 						"mso_position_vertical_relative==null.  What to do?");
-				
+
 			} else {
 
 				if ( mso_position_vertical_relative.equals("text")) {
-					
+
 					// Just lay it out in the flow; graceful degradation
-					Element ret = doc.createElementNS(XSL_FO, "block");  
+					Element ret = doc.createElementNS(XSL_FO, "block");
 					setBorders(ret); // for now, solid borders, so we can see the text box
-					
+
 					String margin_top = props.get("margin-top");
 					if (margin_top==null) {
 						log.error("margin top prop not found.  What to do?");
@@ -233,69 +235,69 @@ public abstract class FOPictWriterAbstract extends AbstractPictWriter {
 						return ret;
 					} else {
 						float marginTop = parsePtsVal(margin_top);
-						
-						
+
+
 						if (foRendererSupportsFoFloat()) {
-							
+
 							// TODO not tested; need a renderer which supports float
-							
+
 							String mso_position_horizontal_relative = props.get("mso-position-horizontal-relative");
 							String mso_position_horizontal = props.get("mso-position-horizontal"); // eg center
-							
-							
+
+
 							if (mso_position_horizontal_relative==null) {
-								log.warn("No support for mso_position_horizontal_relative==null");							
+								log.warn("No support for mso_position_horizontal_relative==null");
 								XmlUtils.treeCopy(modelContent.getChildNodes(), ret);
 								return ret;
 							} else if (!mso_position_horizontal_relative.equals("text") ) {
-								log.warn("No support for mso_position_horizontal_relative==" + mso_position_horizontal_relative.equals("text"));							
+								log.warn("No support for mso_position_horizontal_relative==" + mso_position_horizontal_relative.equals("text"));
 								XmlUtils.treeCopy(modelContent.getChildNodes(), ret);
 								return ret;
 							} else {  // mso_position_horizontal_relative.equals("text")
 
-								
+
 								float ml = parsePtsVal(props.get("margin-left"));
-								
+
 								if (mso_position_horizontal==null) {
-									
-									log.warn("No support for mso_position_horizontal==null");							
-									XmlUtils.treeCopy(modelContent.getChildNodes(), ret);								
+
+									log.warn("No support for mso_position_horizontal==null");
+									XmlUtils.treeCopy(modelContent.getChildNodes(), ret);
 									return ret;
 								}
 								else if ( mso_position_horizontal.equals("absolute")) {
 									// eg in Word UI, "Absolute position to right of column"
-									
+
 									// We can only float left or right (not center etc)
 									log.warn("Degrading absolute position to left/right");
 									if (ml/writableWidthPts <= 0.5) {
 										mso_position_horizontal = "left";
 									} else {
-										mso_position_horizontal = "right";					
+										mso_position_horizontal = "right";
 									}
 								}
-								
-								ret = doc.createElementNS(XSL_FO, "float");  
+
+								ret = doc.createElementNS(XSL_FO, "float");
 								setBorders(ret); // for now, solid borders, so we can see the text box
-								
+
 								if ( mso_position_horizontal.equals("left")) {
 
 									ret.setAttribute("float",  "start");
-																		
+
 								} else if ( mso_position_horizontal.equals("center")) {
-									
+
 									log.warn("Degrading center to right");
 									ret.setAttribute("float",  "end");
-									
+
 								} else if ( mso_position_horizontal.equals("right")) {
-									
+
 									ret.setAttribute("float",  "end");
-								} 
-								XmlUtils.treeCopy(modelContent.getChildNodes(), ret);								
-									
-							} 							
+								}
+								XmlUtils.treeCopy(modelContent.getChildNodes(), ret);
+
+							}
 						} else {
 							//  FOP does not support float, so the best we can do is ...
-							
+
 							if (marginTop<=0) {
 								// The text box is above the para
 								marginTopZeroCase( props, ret, writableWidthPts);
@@ -305,183 +307,184 @@ public abstract class FOPictWriterAbstract extends AbstractPictWriter {
 								// We'll assume here it is next to (since we don't know how long the para is)
 								// Implement with a table (simulating float) .. simple mindedly put the textbox either left or right.
 								// Obviously this won't work if the para had 2 text boxes, one to left and other to right..
-								
-								ret = doc.createElementNS(XSL_FO, "table");  
+
+								ret = doc.createElementNS(XSL_FO, "table");
 								if (marginTopPositiveCase(foRenderer, props, doc, ret, writableWidthPts, modelContent.getChildNodes())) {
-									
+
 								} else {
 									// Couldn't do it.
-									ret = doc.createElementNS(XSL_FO, "block");  
+									ret = doc.createElementNS(XSL_FO, "block");
 									setBorders(ret); // for now, solid borders, so we can see the text box
-									XmlUtils.treeCopy(modelContent.getChildNodes(), ret);								
+									XmlUtils.treeCopy(modelContent.getChildNodes(), ret);
 								}
 							}
-						
+
 						}
 					}
-					
+
 					log.debug(XmlUtils.w3CDomNodeToString(ret));
-					
-					return ret;		
-					
+
+					return ret;
+
 				}  else if (foRendererSupportsFoFloat()) {
-					
+
 					// NB supportsFloat code is untested.
-					
+
 					if  (mso_position_vertical_relative.equals("page")
 							|| mso_position_vertical_relative.equals("top-margin-area")
-							|| mso_position_vertical_relative.equals("bottom-margin-area")) { 
+							|| mso_position_vertical_relative.equals("bottom-margin-area")) {
 
-						if ( mso_position_vertical_relative.equals("page")) { 
-							
+						if ( mso_position_vertical_relative.equals("page")) {
+
 							if (mso_position_vertical.equals("top")) {
 
-								Element ret = doc.createElementNS(XSL_FO, "float"); 
+								Element ret = doc.createElementNS(XSL_FO, "float");
 								ret.setAttribute("float", "before");
 								setBorders(ret); // for now, solid borders, so we can see the text box
 
 								log.debug(XmlUtils.w3CDomNodeToString(ret));
-								return ret;		
-								
+								return ret;
+
 							} else if (mso_position_vertical.equals("bottom")) {
-								
-								Element ret = doc.createElementNS(XSL_FO, "footnote"); 
-								Element footnoteBody = doc.createElementNS(XSL_FO, "footnote-body"); 
+
+								Element ret = doc.createElementNS(XSL_FO, "footnote");
+								Element footnoteBody = doc.createElementNS(XSL_FO, "footnote-body");
 								ret.appendChild(footnoteBody);
-								Element block = doc.createElementNS(XSL_FO, "block"); 
+								Element block = doc.createElementNS(XSL_FO, "block");
 								footnoteBody.appendChild(block);
 								setBorders(block); // for now, solid borders, so we can see the text box
-								
+
 								XmlUtils.treeCopy(modelContent.getChildNodes(), block);
 								return ret;
-								
-								
+
+
 							} else {
-								
-								log.warn("No support for mso_position_vertical==" + mso_position_vertical);							
-								return context.getMessageWriter().message(context, 
+
+								log.warn("No support for mso_position_vertical==" + mso_position_vertical);
+								return context.getMessageWriter().message(context,
 										"TODO for fo:float capable renderer, support no-wrap + mso-position-vertical=" + mso_position_vertical);
 							}
-							
-												
-						} else if ( mso_position_vertical_relative.equals("top-margin-area")) { 
-							
-							Element ret = doc.createElementNS(XSL_FO, "float"); 
+
+
+						} else if ( mso_position_vertical_relative.equals("top-margin-area")) {
+
+							Element ret = doc.createElementNS(XSL_FO, "float");
 							ret.setAttribute("float", "before");
 							setBorders(ret); // for now, solid borders, so we can see the text box
 
 							log.debug(XmlUtils.w3CDomNodeToString(ret));
-							return ret;		
-												
-						} else if (  mso_position_vertical_relative.equals("bottom-margin-area")) { 
+							return ret;
 
-							Element ret = doc.createElementNS(XSL_FO, "footnote"); 
-							Element footnoteBody = doc.createElementNS(XSL_FO, "footnote-body"); 
+						} else if (  mso_position_vertical_relative.equals("bottom-margin-area")) {
+
+							Element ret = doc.createElementNS(XSL_FO, "footnote");
+							Element footnoteBody = doc.createElementNS(XSL_FO, "footnote-body");
 							ret.appendChild(footnoteBody);
-							Element block = doc.createElementNS(XSL_FO, "block"); 
+							Element block = doc.createElementNS(XSL_FO, "block");
 							footnoteBody.appendChild(block);
 							setBorders(block); // for now, solid borders, so we can see the text box
-							
+
 							XmlUtils.treeCopy(modelContent.getChildNodes(), block);
 							return ret;
-												
+
 						} else {
 
 							// Can't happen
-							return context.getMessageWriter().message(context, 
+							return context.getMessageWriter().message(context,
 									"TODO (how did we get here?) mso-position-vertical-relative=" + mso_position_vertical_relative);
-							
+
 						}
 					}  else {
 
-						return context.getMessageWriter().message(context, 
+						return context.getMessageWriter().message(context,
 								"TODO for fo:float capable renderer, support no-wrap + mso-position-vertical-relative=" + mso_position_vertical_relative);
-						
+
 					}
-						
+
 				} else {
-					
-					return context.getMessageWriter().message(context, 
+
+					return context.getMessageWriter().message(context,
 							"TODO for fo:float INcapable renderer, support no-wrap + mso-position-vertical-relative=" + mso_position_vertical_relative);
-					
+
 				}
-				
+
 			}
-			
+
 		} else {
 			// not wrap, so use
-			// block-container .. text does not wrap around 
-			// .. see https://www.ecrion.com/help/products/xfrenderingserver/xfultrascalehelp4/absolut_positioning.htm  
+			// block-container .. text does not wrap around
+			// .. see https://www.ecrion.com/help/products/xfrenderingserver/xfultrascalehelp4/absolut_positioning.htm
 
 			// not wrap: can use fo:block-container/@position= fixed to approximate relative to page
 			log.debug("textbox - over/behind docx text");
-			Element ret = doc.createElementNS(XSL_FO, "block-container");  
-			XmlUtils.treeCopy(modelContent.getChildNodes(), ret);								
-			
+			Element ret = doc.createElementNS(XSL_FO, "block-container");
+			XmlUtils.treeCopy(modelContent.getChildNodes(), ret);
+
 			setBorders(ret); // for now, solid borders, so we can see the text box
-			
-			
+
+
 			String mso_position_horizontal_relative = props.get("mso-position-horizontal-relative");
 			String mso_position_horizontal = props.get("mso-position-horizontal"); // eg center
-			
-			
+
+
 			if (mso_position_horizontal_relative==null) {
-				log.warn("No support for mso_position_horizontal_relative==null");							
+				log.warn("No support for mso_position_horizontal_relative==null");
 			} else if (!mso_position_horizontal_relative.equals("text") ) {
-				log.warn("No support for mso_position_horizontal_relative==" + mso_position_horizontal_relative.equals("text"));							
+				log.warn("No support for mso_position_horizontal_relative==" + mso_position_horizontal_relative.equals("text"));
 			} else {  // mso_position_horizontal_relative.equals("text")
-				
+
 				float boxWidth = parsePtsVal(props.get("width"));
-			
+
 				ret.setAttribute("width",  props.get("width") );
 				ret.setAttribute("height",  props.get("height") );
-				
+
 				if (mso_position_horizontal==null) {
-					
-					log.warn("No support for mso_position_horizontal==null");							
-					
+
+					log.warn("No support for mso_position_horizontal==null");
+
 				} else if ( mso_position_horizontal.equals("left")) {
 
 					ret.setAttribute("left",  "0pt");
-												
+
 				} else if ( mso_position_horizontal.equals("center")) {
-					
+
 					// convert width:186.95pt to margin setting
-					int marginLeft = Math.round((writableWidthPts - boxWidth)/2); 
-					
+					int marginLeft = Math.round((writableWidthPts - boxWidth)/2);
+
 					ret.setAttribute("left", marginLeft + "pt");
-					
+
 				} else if ( mso_position_horizontal.equals("right")) {
-					
+
 					// page width - box width
-					int marginLeft = Math.round((writableWidthPts - boxWidth)); 
+					int marginLeft = Math.round((writableWidthPts - boxWidth));
 					ret.setAttribute("left", marginLeft + "pt");
-					
+
 				} else if ( mso_position_horizontal.equals("absolute")) {
 					// eg in Word UI, "Absolute position to right of column"
 
-					// eg margin-left:108pt	
+					// eg margin-left:108pt
 					ret.setAttribute("margin-left", props.get("margin-left") );
 				}
-					
-			} 					
 
-			ret.setAttribute("z-index", props.get("z-index") );					
+			}
 
-			
+			ret.setAttribute("z-index", props.get("z-index") );
+
+
 			String margin_top = props.get("margin-top");
 			if (mso_position_vertical_relative==null) {
-				
-				log.warn(XmlUtils.marshaltoString(shape));
-				return context.getMessageWriter().message(context, 
+				if(log.isWarnEnabled()) {
+                    log.warn(XmlUtils.marshaltoString(shape));
+                }
+				return context.getMessageWriter().message(context,
 						"mso_position_vertical_relative==null.  What to do?");
-				
+
 			} else {
 
 				if ( mso_position_vertical_relative.equals("text")) {
 
 					ret.setAttribute("position", "absolute");
-					
+
 					// @top
 					if (margin_top==null) {
 						// ret.setAttribute("top", "0pt");
@@ -489,19 +492,19 @@ public abstract class FOPictWriterAbstract extends AbstractPictWriter {
 						//float marginTop = parsePtsVal(margin_top);
 						ret.setAttribute("top", margin_top);
 					}
-										
+
 					log.debug(XmlUtils.w3CDomNodeToString(ret));
-					
-					return ret;		
-					
+
+					return ret;
+
 				} else if ( mso_position_vertical_relative.equals("page")
 						|| mso_position_vertical_relative.equals("top-margin-area")
-						|| mso_position_vertical_relative.equals("bottom-margin-area")) { 
+						|| mso_position_vertical_relative.equals("bottom-margin-area")) {
 
 					ret.setAttribute("position", "fixed");  // relative to page
-					
-					if ( mso_position_vertical_relative.equals("page")) { 
-						
+
+					if ( mso_position_vertical_relative.equals("page")) {
+
 						if (mso_position_vertical.equals("top")) {
 
 							// @top
@@ -511,26 +514,26 @@ public abstract class FOPictWriterAbstract extends AbstractPictWriter {
 								//float marginTop = parsePtsVal(margin_top);
 								ret.setAttribute("top", margin_top);
 							}
-							
+
 						} else if (mso_position_vertical.equals("bottom")) {
-							
-							//float boxHeight = parsePtsVal(props.get("height"));						
+
+							//float boxHeight = parsePtsVal(props.get("height"));
 							//int top = Math.round(writableHeightPts - boxHeight);
-							
+
 							int top = Math.round(writableHeightPts );
 							ret.setAttribute("top", top + "pt");
-							
+
 						} else {
-							
-							log.warn("No support for mso_position_vertical==" + mso_position_vertical);							
-							
+
+							log.warn("No support for mso_position_vertical==" + mso_position_vertical);
+
 						}
-						
+
 						log.debug(XmlUtils.w3CDomNodeToString(ret));
-						return ret;		
-											
-					} else if ( mso_position_vertical_relative.equals("top-margin-area")) { 
-						
+						return ret;
+
+					} else if ( mso_position_vertical_relative.equals("top-margin-area")) {
+
 						// @top
 						if (margin_top==null) {
 							// ret.setAttribute("top", "0pt");
@@ -538,94 +541,94 @@ public abstract class FOPictWriterAbstract extends AbstractPictWriter {
 							//float marginTop = parsePtsVal(margin_top);
 							ret.setAttribute("top", margin_top);
 						}
-						
-						log.debug(XmlUtils.w3CDomNodeToString(ret));
-						return ret;		
-											
-					} else if (  mso_position_vertical_relative.equals("bottom-margin-area")) { 
 
-						//float boxHeight = parsePtsVal(props.get("height"));						
+						log.debug(XmlUtils.w3CDomNodeToString(ret));
+						return ret;
+
+					} else if (  mso_position_vertical_relative.equals("bottom-margin-area")) {
+
+						//float boxHeight = parsePtsVal(props.get("height"));
 						//int top = Math.round(writableHeightPts - boxHeight);
-						
+
 						int top = Math.round(writableHeightPts );
 						ret.setAttribute("top", top + "pt");
-						
+
 						log.debug(XmlUtils.w3CDomNodeToString(ret));
-						return ret;		
-											
+						return ret;
+
 					} else {
 
 						// Can't happen
-						return context.getMessageWriter().message(context, 
+						return context.getMessageWriter().message(context,
 								"TODO (how did we get here?) mso-position-vertical-relative=" + mso_position_vertical_relative);
-						
+
 					}
 				}  else {
 
-					return context.getMessageWriter().message(context, 
+					return context.getMessageWriter().message(context,
 							"TODO support no-wrap + mso-position-vertical-relative=" + mso_position_vertical_relative);
-					
+
 				}
-				
+
 			}
-			
+
 		}
-		
+
 	}
-	
+
 	private void setBorders(Element ret) {
 		ret.setAttribute("border-left-style", "solid");
 		ret.setAttribute("border-top-style", "solid");
 		ret.setAttribute("border-bottom-style", "solid");
 		ret.setAttribute("border-right-style", "solid");
-		
+
 	}
 
 	private Map<String, String> getProperties(String s) {
-		
+
 		Map<String, String> map = new HashMap<String, String>();
-		
+
 		if (s==null) {
 			log.warn("shape has no @style");
 			return map;
 		}
-		
+
 		for(final String entry : s.split(";")) {
 		    final String[] parts = entry.split(":");
 		    assert(parts.length == 2) : "Invalid entry: " + entry;
 		    map.put(parts[0], parts[1]);
-		}		
+		}
 		return map;
-		
+
 	}
 
 	private float parsePtsVal(String pts) {
-		
+
 		if (pts==null) {
 			log.warn("No val!");
 			return -99; // or exception?
-			
+
 		} else if (pts.contains("pt")) {
 
 			pts = pts.substring(0, pts.indexOf("pt"));
 			return Float.parseFloat(pts);
-			
+
 		} else if (pts.equals("0")) {
-			
+
 			return 0;
-			
+
 		} else {
 
 			log.warn("Unit is not points! " + pts);
 			return -99; // or exception?
-			
+
 		}
-		
+
 	}
-	
+
 	/**
 	 * Wrap case, for renderers which don't support fo:float (eg Apache FOP)
-	 * 
+	 *
 	 * @param props
 	 * @param ret
 	 * @param widthPts
@@ -634,68 +637,68 @@ public abstract class FOPictWriterAbstract extends AbstractPictWriter {
 
 //		mso-position-horizontal:center
 //		mso-position-horizontal-relative:text
-		
+
 		String mso_position_horizontal_relative = props.get("mso-position-horizontal-relative");
 		String mso_position_horizontal = props.get("mso-position-horizontal"); // eg center
-		
-		
+
+
 		if (mso_position_horizontal_relative==null) {
-			log.warn("No support for mso_position_horizontal_relative==null");							
+			log.warn("No support for mso_position_horizontal_relative==null");
 		} else if (!mso_position_horizontal_relative.equals("text") ) {
-			log.warn("No support for mso_position_horizontal_relative==" + mso_position_horizontal_relative.equals("text"));							
+			log.warn("No support for mso_position_horizontal_relative==" + mso_position_horizontal_relative.equals("text"));
 		} else {  // mso_position_horizontal_relative.equals("text")
 
 			// strategy is to use @margin-left for positioning
 			// (since the margin is outside the block border).
 			// This works for FOP.  If it didn't, I guess we could try using a table
-			
+
 			float boxWidth = parsePtsVal(props.get("width"));
-			
+
 			if (mso_position_horizontal==null) {
-				
-				log.warn("No support for mso_position_horizontal==null");							
-				
+
+				log.warn("No support for mso_position_horizontal==null");
+
 			} else if ( mso_position_horizontal.equals("left")) {
 
 				ret.setAttribute("margin-left",  "0pt");
-				
+
 				// page width - box width
-				int marginRight = Math.round((widthPts - boxWidth)); 
+				int marginRight = Math.round((widthPts - boxWidth));
 				ret.setAttribute("margin-right", marginRight + "pt");
-				
+
 			} else if ( mso_position_horizontal.equals("center")) {
-				
+
 				// convert width:186.95pt to margin setting
-				int marginLeft = Math.round((widthPts - boxWidth)/2); 
-				
+				int marginLeft = Math.round((widthPts - boxWidth)/2);
+
 				ret.setAttribute("margin-left", marginLeft + "pt");
 				ret.setAttribute("margin-right", marginLeft + "pt");
-				
+
 			} else if ( mso_position_horizontal.equals("right")) {
-				
+
 				ret.setAttribute("margin-right",  "0pt");
 				// page width - box width
-				int marginLeft = Math.round((widthPts - boxWidth)); 
+				int marginLeft = Math.round((widthPts - boxWidth));
 				ret.setAttribute("margin-left", marginLeft + "pt");
-				
+
 			} else if ( mso_position_horizontal.equals("absolute")) {
 				// eg in Word UI, "Absolute position to right of column"
 
-				// eg margin-left:108pt	
+				// eg margin-left:108pt
 				ret.setAttribute("margin-left", props.get("margin-left") );
 
 				float ml = parsePtsVal(props.get("margin-left"));
-				int mRight = Math.round((widthPts - (boxWidth+ml))); 
+				int mRight = Math.round((widthPts - (boxWidth+ml)));
 				ret.setAttribute("margin-right",  mRight + "pt");
 			}
-				
-		} 
-		
+
+		}
+
 	}
 
 	/**
 	 * Wrap case, for renderers which don't support fo:float (eg Apache FOP).  Try to degrade gracefully.
-	 * 
+	 *
 	 * @param props
 	 * @param doc
 	 * @param ret
@@ -708,11 +711,11 @@ public abstract class FOPictWriterAbstract extends AbstractPictWriter {
 
 //		mso-position-horizontal:center
 //		mso-position-horizontal-relative:text
-		
+
 		String mso_position_horizontal_relative = props.get("mso-position-horizontal-relative");
 		String mso_position_horizontal = props.get("mso-position-horizontal"); // eg center
-		
-		
+
+
 		if (mso_position_horizontal_relative==null) {
 			log.warn("No support for mso_position_horizontal_relative==null");
 			return false;
@@ -724,19 +727,19 @@ public abstract class FOPictWriterAbstract extends AbstractPictWriter {
 			// strategy is to use @margin-left for positioning
 			// (since the margin is outside the block border).
 			// This works for FOP.  If it didn't, I guess we could try using a table
-			
+
 			float boxWidth = parsePtsVal(props.get("width"));
-			
+
 			if (mso_position_horizontal==null) {
-				
-				log.warn("No support for mso_position_horizontal==null");							
+
+				log.warn("No support for mso_position_horizontal==null");
 				return false;
 			}
 			float ml = parsePtsVal(props.get("margin-left"));
-			
+
 			if ( mso_position_horizontal.equals("absolute")) {
 				// eg in Word UI, "Absolute position to right of column"
-				
+
 				// our simple minded approach here is to treat as left, right or centre ..
 
 				if (ml/widthPts < 0.334) {
@@ -747,12 +750,12 @@ public abstract class FOPictWriterAbstract extends AbstractPictWriter {
 					mso_position_horizontal = "right";
 				} else {
 					// fake center
-					mso_position_horizontal = "center";					
+					mso_position_horizontal = "center";
 				}
 			}
-			
+
 			if ( mso_position_horizontal.equals("left")) {
-				
+
 				Element tcol1 = doc.createElementNS(XSL_FO, "table-column");
 				ret.appendChild(tcol1);
 				tcol1.setAttribute("column-number", "1"); // optional?
@@ -788,34 +791,34 @@ public abstract class FOPictWriterAbstract extends AbstractPictWriter {
 		              </fo:table-cell>
 		            </fo:table-row>
 		          </fo:table-body>	
-		          */			
+		          */
 				Element tbody = doc.createElementNS(XSL_FO, "table-body");
 				ret.appendChild(tbody);
 				Element trow = doc.createElementNS(XSL_FO, "table-row");
 				tbody.appendChild(trow);
-				
+
 				// Cell 1 is the text box
 				Element tc1 = doc.createElementNS(XSL_FO, "table-cell");
-				trow.appendChild(tc1);				
-				Element block = doc.createElementNS(XSL_FO, "block");  
+				trow.appendChild(tc1);
+				Element block = doc.createElementNS(XSL_FO, "block");
 
-				
+
 				setBorders(block); // for now, solid borders, so we can see the text box
 				tc1.appendChild(block);
 				XmlUtils.treeCopy(childNodes, block);
-				
+
 				// Cell 2 is the p content proper (which we don't have)
 				Element tc2 = doc.createElementNS(XSL_FO, "table-cell");
-				trow.appendChild(tc2);	
+				trow.appendChild(tc2);
 //				tc2.appendChild(
 //						doc.createComment("CONTENT GOES HERE"));
-				Element placeholder = doc.createElementNS(XSL_FO, "block");  
+				Element placeholder = doc.createElementNS(XSL_FO, "block");
 				placeholder.setTextContent("#TEXTBOX#"); // magic string
 				tc2.appendChild(placeholder);
-				
+
 				// TODO here the architecture needs further thought
 				if (foRenderer instanceof AbstractFORenderer) {
-					
+
 					((AbstractFORenderer)foRenderer).TEXTBOX_POSTPROCESSING_REQUIRED = true;
 						// currently done in the render step in FORendererApacheFOP
 						// Maybe it should be done in AbstractFOExporter.postprocess,
@@ -823,19 +826,19 @@ public abstract class FOPictWriterAbstract extends AbstractPictWriter {
 				} else {
 					log.warn("TODO: implement TEXTBOX_POSTPROCESSING_REQUIRED for " + foRenderer.getClass().getName() );
 				}
-				
+
 				return true;
-				
+
 			} else if ( mso_position_horizontal.equals("center")) {
-				
+
 				// use 3 cells
 				// No, can't do it...
 				// best we could do would be to put the textbox centred
 				// below the text.
 				log.warn("Can't support mso_position_horizontal:center");
-				
+
 				return false;
-				
+
 			} else if ( mso_position_horizontal.equals("right")) {
 
 				Element tcol1 = doc.createElementNS(XSL_FO, "table-column");
@@ -851,7 +854,7 @@ public abstract class FOPictWriterAbstract extends AbstractPictWriter {
 				// width of left cell is ml + boxWidth
 				int col2W = Math.round(boxWidth);
 				tcol2.setAttribute("column-width", col2W +"pt");
-				
+
 				Element tbody = doc.createElementNS(XSL_FO, "table-body");
 				ret.appendChild(tbody);
 				Element trow = doc.createElementNS(XSL_FO, "table-row");
@@ -859,24 +862,24 @@ public abstract class FOPictWriterAbstract extends AbstractPictWriter {
 
 				// Cell 1 is the p content proper (which we don't have)
 				Element tc1 = doc.createElementNS(XSL_FO, "table-cell");
-				trow.appendChild(tc1);	
+				trow.appendChild(tc1);
 //				tc2.appendChild(
 //						doc.createComment("CONTENT GOES HERE"));
-				Element placeholder = doc.createElementNS(XSL_FO, "block");  
+				Element placeholder = doc.createElementNS(XSL_FO, "block");
 				placeholder.setTextContent("#TEXTBOX#"); // magic string
 				tc1.appendChild(placeholder);
-				
+
 				// Cell 2 is the text box
 				Element tc2 = doc.createElementNS(XSL_FO, "table-cell");
-				trow.appendChild(tc2);				
-				Element block = doc.createElementNS(XSL_FO, "block");  
+				trow.appendChild(tc2);
+				Element block = doc.createElementNS(XSL_FO, "block");
 				setBorders(block); // for now, solid borders, so we can see the text box
 				tc2.appendChild(block);
 				XmlUtils.treeCopy(childNodes, block);
-				
+
 				// TODO here the architecture needs further thought
 				if (foRenderer instanceof AbstractFORenderer) {
-					
+
 					((AbstractFORenderer)foRenderer).TEXTBOX_POSTPROCESSING_REQUIRED = true;
 						// currently done in the render step in FORendererApacheFOP
 						// Maybe it should be done in AbstractFOExporter.postprocess,
@@ -884,14 +887,14 @@ public abstract class FOPictWriterAbstract extends AbstractPictWriter {
 				} else {
 					log.warn("TODO: implement TEXTBOX_POSTPROCESSING_REQUIRED for " + foRenderer.getClass().getName() );
 				}
-				
+
 				return true;
-				
-			} 
+
+			}
 			return false;
-				
-		} 
-		
+
+		}
+
 	}
-	
+
 }

--- a/src/main/java/org/docx4j/convert/out/fo/LayoutMasterSetBuilder.java
+++ b/src/main/java/org/docx4j/convert/out/fo/LayoutMasterSetBuilder.java
@@ -19,12 +19,6 @@
  */
 package org.docx4j.convert.out.fo;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
-
 import org.docx4j.UnitsOfMeasurement;
 import org.docx4j.XmlUtils;
 import org.docx4j.convert.out.FOSettings;
@@ -55,6 +49,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.DocumentFragment;
 import org.w3c.dom.Node;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
 
 
 
@@ -113,8 +113,10 @@ public class LayoutMasterSetBuilder {
 		startEvent.publish();
 		
 //		log.debug(wordMLPackage.getMainDocumentPart().getXML());
-		
-		log.debug("incoming LMS: " + XmlUtils.marshaltoString(lms, Context.getXslFoContext()));
+
+        if(log.isDebugEnabled()) {
+            log.debug("incoming LMS: " + XmlUtils.marshaltoString(lms, Context.getXslFoContext()));
+        }
 		
 		// Make a copy of it
 		Set<String> relationshipTypes = new TreeSet<String>();
@@ -154,7 +156,9 @@ public class LayoutMasterSetBuilder {
 		} catch (Exception e) {
 			log.error(e.getMessage(), e);
 		}
-		log.debug("resulting LMS: " + XmlUtils.marshaltoString(lms, Context.getXslFoContext()));
+        if(log.isDebugEnabled()) {
+            log.debug("resulting LMS: " + XmlUtils.marshaltoString(lms, Context.getXslFoContext()));
+        }
 		
 		new EventFinished(startEvent).publish();
 		

--- a/src/main/java/org/docx4j/fonts/RunFontSelector.java
+++ b/src/main/java/org/docx4j/fonts/RunFontSelector.java
@@ -1,8 +1,5 @@
 package org.docx4j.fonts;
 
-import java.awt.font.NumericShaper;
-import java.util.concurrent.ExecutionException;
-
 import org.docx4j.Docx4jProperties;
 import org.docx4j.XmlUtils;
 import org.docx4j.model.PropertyResolver;
@@ -23,6 +20,9 @@ import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.DocumentFragment;
 import org.w3c.dom.Element;
+
+import java.awt.font.NumericShaper;
+import java.util.concurrent.ExecutionException;
 
 /**
  * Apply the appropriate font to the characters in the run,
@@ -369,8 +369,10 @@ public class RunFontSelector {
     	rPr = propertyResolver.getEffectiveRPrUsingPStyleRPr(rPr, pRPr); 
     	// TODO use effective rPr, but don't inherit theme val,
     	// TODO, add cache?
-    	
-    	log.debug("effective\n" + XmlUtils.marshaltoString(rPr));
+
+    	if(log.isDebugEnabled()) {
+            log.debug("effective\n" + XmlUtils.marshaltoString(rPr));
+        }
     	
     	/* eg
     	 * 
@@ -433,8 +435,10 @@ public class RunFontSelector {
 //    					|| fontName.trim().length()==0
     					) {
     				// then what?
-    				log.warn("font name is null, for " + text);
-    				log.warn(XmlUtils.marshaltoString(rPr, true, true));
+                    if(log.isWarnEnabled()) {
+                        log.warn("font name is null, for " + text);
+                        log.warn(XmlUtils.marshaltoString(rPr, true, true));
+                    }
     				(new Throwable()).printStackTrace();
     			}    		
     			

--- a/src/main/java/org/docx4j/model/PropertyResolver.java
+++ b/src/main/java/org/docx4j/model/PropertyResolver.java
@@ -175,7 +175,9 @@ public class PropertyResolver {
 		initialiseLiveStyles();		
 		
 		Style docDefaults = styleDefinitionsPart.getStyleById("DocDefaults");
-		log.debug(XmlUtils.marshaltoString(docDefaults, true, true));
+        if(log.isDebugEnabled()) {
+            log.debug(XmlUtils.marshaltoString(docDefaults, true, true));
+        }
 		documentDefaultPPr = docDefaults.getPPr();
 		documentDefaultRPr = docDefaults.getRPr();
 
@@ -343,7 +345,9 @@ public class PropertyResolver {
 		} else {
 			styleId = expressPPr.getPStyle().getVal();
 			if (styleId==null) {
-				log.warn("Missing style id: " + XmlUtils.marshaltoString(expressPPr));
+                if(log.isWarnEnabled()) {
+                    log.warn("Missing style id: " + XmlUtils.marshaltoString(expressPPr));
+                }
 				if (log.isDebugEnabled()) {
 					Throwable t = new Throwable();
 					log.debug("Null styleId produced by code path", t);
@@ -617,7 +621,9 @@ public class PropertyResolver {
 		// Now, apply the properties starting at the top of the stack
 		while (!rPrStack.empty() ) {
 			RPr rPr = rPrStack.pop();
-			log.debug("applying " + XmlUtils.marshaltoString(rPr));
+            if(log.isDebugEnabled()) {
+                log.debug("applying " + XmlUtils.marshaltoString(rPr));
+            }
 			applyRPr(rPr, resolvedRPr);
 		}
 		resolvedStyleRPrComponent.put(styleId, resolvedRPr);
@@ -751,9 +757,10 @@ public class PropertyResolver {
 	
 	
 	protected void applyPPr(PPr pPrToApply, PPr effectivePPr) {
-		
-		log.debug( "apply " + XmlUtils.marshaltoString(pPrToApply,  true, true)
-			+ "\n\r to " + XmlUtils.marshaltoString(effectivePPr,  true, true) );
+        if(log.isDebugEnabled()) {
+            log.debug("apply " + XmlUtils.marshaltoString(pPrToApply, true, true)
+                    + "\n\r to " + XmlUtils.marshaltoString(effectivePPr, true, true));
+        }
 		
 		StyleUtil.apply(pPrToApply, effectivePPr);
 		
@@ -769,7 +776,9 @@ public class PropertyResolver {
 //			}
 //    	}
 
-		log.debug( "result " + XmlUtils.marshaltoString(effectivePPr,  true, true) );
+        if(log.isDebugEnabled()) {
+            log.debug("result " + XmlUtils.marshaltoString(effectivePPr, true, true));
+        }
     	
 	}
 	

--- a/src/main/java/org/docx4j/model/datastorage/BindingTraverserNonXSLT.java
+++ b/src/main/java/org/docx4j/model/datastorage/BindingTraverserNonXSLT.java
@@ -19,14 +19,6 @@
  **/
 package org.docx4j.model.datastorage;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.StringTokenizer;
-
-import javax.xml.bind.JAXBException;
-
 import org.apache.commons.codec.binary.Base64;
 import org.apache.xmlgraphics.image.loader.ImageSize;
 import org.docx4j.TraversalUtil;
@@ -42,7 +34,6 @@ import org.docx4j.openpackaging.packages.WordprocessingMLPackage;
 import org.docx4j.openpackaging.parts.CustomXmlPart;
 import org.docx4j.openpackaging.parts.JaxbXmlPart;
 import org.docx4j.openpackaging.parts.WordprocessingML.BinaryPartAbstractImage;
-import org.docx4j.openpackaging.parts.opendope.XPathsPart;
 import org.docx4j.openpackaging.parts.relationships.Namespaces;
 import org.docx4j.wml.Body;
 import org.docx4j.wml.CTDataBinding;
@@ -62,6 +53,13 @@ import org.docx4j.wml.Tr;
 import org.jvnet.jaxb2_commons.ppp.Child;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.xml.bind.JAXBException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.StringTokenizer;
 
 public class BindingTraverserNonXSLT extends BindingTraverserCommonImpl {
 	
@@ -211,8 +209,9 @@ public class BindingTraverserNonXSLT extends BindingTraverserCommonImpl {
 							null, false));
 				
 			} else {
-				
-				log.debug("Not processing " + XmlUtils.marshaltoString(sdtPr, true));
+				if(log.isDebugEnabled()) {
+                    log.debug("Not processing " + XmlUtils.marshaltoString(sdtPr, true));
+                }
 				 
 			}
 			
@@ -337,8 +336,10 @@ public class BindingTraverserNonXSLT extends BindingTraverserCommonImpl {
 						if (sdtParent instanceof SdtRun) {
 							return run;							
 						} else {
-						log.error("empty image template in sdt: " + XmlUtils.marshaltoString(sdt.getSdtPr(), true)
-								+  sdtParent.getClass().getName());
+                            if(log.isErrorEnabled()) {
+                                log.error("empty image template in sdt: " + XmlUtils.marshaltoString(sdt.getSdtPr(), true)
+                                        + sdtParent.getClass().getName());
+                            }
 						}
 					} else {
 						Object contentChild = sdtContent.get(0);

--- a/src/main/java/org/docx4j/model/datastorage/BindingTraverserXSLT.java
+++ b/src/main/java/org/docx4j/model/datastorage/BindingTraverserXSLT.java
@@ -1,41 +1,14 @@
 package org.docx4j.model.datastorage;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Method;
-import java.math.BigInteger;
-import java.nio.ByteBuffer;
-import java.text.DateFormat;
-import java.text.Format;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.StringTokenizer;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import javax.xml.bind.JAXBException;
-import javax.xml.transform.Source;
-import javax.xml.transform.Templates;
-import javax.xml.transform.TransformerConfigurationException;
-import javax.xml.transform.dom.DOMResult;
-import javax.xml.transform.stream.StreamSource;
-
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.IOUtils;
 import org.apache.xalan.extensions.ExpressionContext;
 import org.apache.xmlgraphics.image.loader.ImageSize;
 import org.docx4j.Docx4jProperties;
-import org.docx4j.TraversalUtil;
 import org.docx4j.XmlUtils;
 import org.docx4j.convert.in.xhtml.XHTMLImporter;
 import org.docx4j.convert.out.html.HtmlCssHelper;
 import org.docx4j.dml.wordprocessingDrawing.Inline;
-import org.docx4j.finders.RangeFinder;
 import org.docx4j.jaxb.Context;
 import org.docx4j.model.sdt.QueryString;
 import org.docx4j.model.styles.StyleTree;
@@ -52,7 +25,6 @@ import org.docx4j.openpackaging.parts.PartName;
 import org.docx4j.openpackaging.parts.WordprocessingML.AltChunkType;
 import org.docx4j.openpackaging.parts.WordprocessingML.AlternativeFormatInputPart;
 import org.docx4j.openpackaging.parts.WordprocessingML.BinaryPartAbstractImage;
-import org.docx4j.openpackaging.parts.opendope.XPathsPart;
 import org.docx4j.openpackaging.parts.relationships.Namespaces;
 import org.docx4j.openpackaging.parts.relationships.RelationshipsPart;
 import org.docx4j.relationships.Relationship;
@@ -60,7 +32,6 @@ import org.docx4j.utils.ResourceUtils;
 import org.docx4j.w14.CTSdtCheckbox;
 import org.docx4j.w14.CTSdtCheckboxSymbol;
 import org.docx4j.wml.CTAltChunk;
-import org.docx4j.wml.CTBookmark;
 import org.docx4j.wml.CTDataBinding;
 import org.docx4j.wml.CTSdtDate;
 import org.docx4j.wml.Color;
@@ -77,6 +48,29 @@ import org.w3c.dom.Document;
 import org.w3c.dom.DocumentFragment;
 import org.w3c.dom.Node;
 import org.w3c.dom.traversal.NodeIterator;
+
+import javax.xml.bind.JAXBException;
+import javax.xml.transform.Source;
+import javax.xml.transform.Templates;
+import javax.xml.transform.TransformerConfigurationException;
+import javax.xml.transform.dom.DOMResult;
+import javax.xml.transform.stream.StreamSource;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+import java.text.DateFormat;
+import java.text.Format;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.StringTokenizer;
+import java.util.concurrent.atomic.AtomicInteger;
 
 
 public class BindingTraverserXSLT extends BindingTraverserCommonImpl {
@@ -642,8 +636,9 @@ public class BindingTraverserXSLT extends BindingTraverserCommonImpl {
 				for(Object o : results) {
 					
 					if (sdtParent.equals("p") && o instanceof P) {
-						log.warn("DISCARDING conversion result (can't add in context p): " + XmlUtils.marshaltoString(o, true));
-						
+                        if(log.isWarnEnabled()) {
+                            log.warn("DISCARDING conversion result (can't add in context p): " + XmlUtils.marshaltoString(o, true));
+                        }
 					} else if (log.isDebugEnabled()) {
 						log.debug("Conversion result: " + XmlUtils.marshaltoString(o, true));						
 					}
@@ -1105,22 +1100,32 @@ public class BindingTraverserXSLT extends BindingTraverserCommonImpl {
 			if (sdtParent.equals("body")
 					|| sdtParent.equals("tc") ) {
 				document = XmlUtils.marshaltoW3CDomDocument(p);
-				log.debug(XmlUtils.marshaltoString(p, true, true));
+                if(log.isDebugEnabled()) {
+                    log.debug(XmlUtils.marshaltoString(p, true, true));
+                }
 			} else if ( sdtParent.equals("tr") ) {
 				document = XmlUtils.marshaltoW3CDomDocument(tc);
-				log.debug(XmlUtils.marshaltoString(tc, true, true));
+                if(log.isDebugEnabled()) {
+                    log.debug(XmlUtils.marshaltoString(tc, true, true));
+                }
 			} else if ( sdtParent.equals("p") ) {
 				document = XmlUtils.marshaltoW3CDomDocument(run);
-				log.debug(XmlUtils.marshaltoString(run, true, true));
+                if(log.isDebugEnabled()) {
+                    log.debug(XmlUtils.marshaltoString(run, true, true));
+                }
 			} else if ( sdtParent.equals("sdtContent") ) {					
 				log.info("contentChild: " + contentChild);
 				if (contentChild.equals("p")) {
 					p.getContent().add(run);
-					document = XmlUtils.marshaltoW3CDomDocument(p);						
-					log.debug(XmlUtils.marshaltoString(p, true, true));
+					document = XmlUtils.marshaltoW3CDomDocument(p);
+                    if(log.isDebugEnabled()) {
+                        log.debug(XmlUtils.marshaltoString(p, true, true));
+                    }
 				} else if (contentChild.equals("r")) {
-					document = XmlUtils.marshaltoW3CDomDocument(run);						
-					log.debug(XmlUtils.marshaltoString(run, true, true));
+					document = XmlUtils.marshaltoW3CDomDocument(run);
+                    if(log.isDebugEnabled()) {
+                        log.debug(XmlUtils.marshaltoString(run, true, true));
+                    }
 				} else {
 					log.error("how to inject image for unexpected sdt's content: " + contentChild);					
 				}
@@ -1617,22 +1622,32 @@ public class BindingTraverserXSLT extends BindingTraverserCommonImpl {
 			if (sdtParent.equals("body")
 					|| sdtParent.equals("tc") ) {
 				document = XmlUtils.marshaltoW3CDomDocument(p);
-				log.debug(XmlUtils.marshaltoString(p, true, true));
+                if(log.isDebugEnabled()) {
+                    log.debug(XmlUtils.marshaltoString(p, true, true));
+                }
 			} else if ( sdtParent.equals("tr") ) {
 				document = XmlUtils.marshaltoW3CDomDocument(tc);
-				log.debug(XmlUtils.marshaltoString(tc, true, true));
+                if(log.isDebugEnabled()) {
+                    log.debug(XmlUtils.marshaltoString(tc, true, true));
+                }
 			} else if ( sdtParent.equals("p") ) {
 				document = XmlUtils.marshaltoW3CDomDocument(run);
-				log.debug(XmlUtils.marshaltoString(run, true, true));
+                if(log.isDebugEnabled()) {
+                    log.debug(XmlUtils.marshaltoString(run, true, true));
+                }
 			} else if ( sdtParent.equals("sdtContent") ) {					
 				log.info("contentChild: " + contentChild);
 				if (contentChild.equals("p")) {
 					p.getContent().add(run);
-					document = XmlUtils.marshaltoW3CDomDocument(p);						
-					log.debug(XmlUtils.marshaltoString(p, true, true));
+					document = XmlUtils.marshaltoW3CDomDocument(p);
+                    if(log.isDebugEnabled()) {
+                        log.debug(XmlUtils.marshaltoString(p, true, true));
+                    }
 				} else if (contentChild.equals("r")) {
-					document = XmlUtils.marshaltoW3CDomDocument(run);						
-					log.debug(XmlUtils.marshaltoString(run, true, true));
+					document = XmlUtils.marshaltoW3CDomDocument(run);
+                    if(log.isDebugEnabled()) {
+                        log.debug(XmlUtils.marshaltoString(run, true, true));
+                    }
 				} else {
 					log.error("how to inject checkbox for unexpected sdt's content: " + contentChild);					
 				}

--- a/src/main/java/org/docx4j/model/datastorage/CustomXmlDataStoragePartSelector.java
+++ b/src/main/java/org/docx4j/model/datastorage/CustomXmlDataStoragePartSelector.java
@@ -20,9 +20,6 @@
  */
 package org.docx4j.model.datastorage;
 
-import java.util.HashMap;
-import java.util.List;
-
 import org.docx4j.XmlUtils;
 import org.docx4j.openpackaging.exceptions.Docx4JException;
 import org.docx4j.openpackaging.packages.WordprocessingMLPackage;
@@ -35,6 +32,9 @@ import org.docx4j.wml.SdtElement;
 import org.opendope.xpaths.Xpaths.Xpath;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.List;
 
 /**
  * Mechanism to find the user's XML data part
@@ -94,7 +94,10 @@ public class CustomXmlDataStoragePartSelector {
 				CustomXmlDataStoragePart customXmlDataStoragePart 
 					= (CustomXmlDataStoragePart)wordMLPackage.getCustomXmlDataStorageParts().get(itemId);
 				if (customXmlDataStoragePart==null) {
-					log.warn("Couldn't find CustomXmlDataStoragePart referenced from " + XmlUtils.marshaltoString(xp));
+                    if(log.isWarnEnabled()) {
+                        log.warn("Couldn't find CustomXmlDataStoragePart referenced from " + XmlUtils.marshaltoString(xp));
+
+                    }
 					continue;			
 				} else {
 					log.debug("Using " + xp.getDataBinding().getStoreItemID());

--- a/src/main/java/org/docx4j/model/datastorage/OpenDoPEHandler.java
+++ b/src/main/java/org/docx4j/model/datastorage/OpenDoPEHandler.java
@@ -95,7 +95,9 @@ public class OpenDoPEHandler {
 		} else {
 			org.opendope.xpaths.Xpaths xPaths = wordMLPackage.getMainDocumentPart().getXPathsPart()
 					.getJaxbElement();
-			log.debug(XmlUtils.marshaltoString(xPaths, true, true));
+            if(log.isDebugEnabled()) {
+                log.debug(XmlUtils.marshaltoString(xPaths, true, true));
+            }
 			
 			xpathsMap = new HashMap<String, org.opendope.xpaths.Xpaths.Xpath>(2*xPaths.getXpath().size());
 			
@@ -111,7 +113,9 @@ public class OpenDoPEHandler {
 		if (wordMLPackage.getMainDocumentPart().getConditionsPart() != null) {
 			org.opendope.conditions.Conditions conditions = wordMLPackage.getMainDocumentPart()
 					.getConditionsPart().getJaxbElement();
-			log.debug(XmlUtils.marshaltoString(conditions, true, true));
+            if(log.isDebugEnabled()) {
+                log.debug(XmlUtils.marshaltoString(conditions, true, true));
+            }
 			
 			conditionsMap = new HashMap<String, Condition>(2*conditions.getCondition().size());
 			
@@ -124,7 +128,9 @@ public class OpenDoPEHandler {
 		if (wordMLPackage.getMainDocumentPart().getComponentsPart() != null) {
 			components = wordMLPackage.getMainDocumentPart()
 					.getComponentsPart().getJaxbElement();
-			log.debug(XmlUtils.marshaltoString(components, true, true));
+            if(log.isDebugEnabled()) {
+                log.debug(XmlUtils.marshaltoString(components, true, true));
+            }
 		}
 
 		shallowTraversor = new ShallowTraversor();
@@ -1213,7 +1219,9 @@ public class OpenDoPEHandler {
 
 		SdtPr sdtPr = getSdtPr(sdt);
 
-		log.debug(XmlUtils.marshaltoString(sdtPr, true, true));
+        if(log.isDebugEnabled()) {
+            log.debug(XmlUtils.marshaltoString(sdtPr, true, true));
+        }
 
 		// CTDataBinding binding =
 		// (CTDataBinding)XmlUtils.unwrap(sdtPr.getDataBinding());
@@ -1524,8 +1532,10 @@ public class OpenDoPEHandler {
 
 			// TODO: this code assumes the condition contains
 			// a simple xpath
-			log.debug("Using condition"
-					+ XmlUtils.marshaltoString(c, true, true));
+            if(log.isDebugEnabled()) {
+                log.debug("Using condition"
+                        + XmlUtils.marshaltoString(c, true, true));
+            }
 
 			Condition newCondition = c.repeat(xpathBase, index, conditionsMap, xpathsMap);
 

--- a/src/main/java/org/docx4j/model/datastorage/migration/FromMergeFields.java
+++ b/src/main/java/org/docx4j/model/datastorage/migration/FromMergeFields.java
@@ -1,8 +1,5 @@
 package org.docx4j.model.datastorage.migration;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.docx4j.TraversalUtil;
 import org.docx4j.XmlUtils;
 import org.docx4j.model.fields.ComplexFieldLocator;
@@ -15,6 +12,9 @@ import org.docx4j.wml.P;
 import org.docx4j.wml.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * This class will help you to migrate
@@ -52,8 +52,10 @@ public class FromMergeFields extends AbstractMigrator {
 		createParts(pkgOut);
 		
 		FieldsPreprocessor.complexifyFields(pkgOut.getMainDocumentPart() );
-		log.debug("complexified: " 
-				+ XmlUtils.marshaltoString(pkgOut.getMainDocumentPart().getJaxbElement(), true));
+        if(log.isDebugEnabled()) {
+            log.debug("complexified: "
+                    + XmlUtils.marshaltoString(pkgOut.getMainDocumentPart().getJaxbElement(), true));
+        }
 		
 		// find fields
 		ComplexFieldLocator fl = new ComplexFieldLocator();
@@ -143,8 +145,10 @@ public class FromMergeFields extends AbstractMigrator {
 		if (o instanceof Text) {
 			return ((Text)o).getValue();
 		} else {
-			log.error("TODO: extract field name from " + o.getClass().getName() );
-			log.error(XmlUtils.marshaltoString(instructions.get(0), true, true) );
+            if(log.isErrorEnabled()) {
+                log.error("TODO: extract field name from " + o.getClass().getName());
+                log.error(XmlUtils.marshaltoString(instructions.get(0), true, true));
+            }
 			return null;
 		}
 	}

--- a/src/main/java/org/docx4j/model/datastorage/migration/VariablePrepare.java
+++ b/src/main/java/org/docx4j/model/datastorage/migration/VariablePrepare.java
@@ -21,14 +21,6 @@
 package org.docx4j.model.datastorage.migration;
 
 
-import java.util.ArrayList;
-import java.util.List;
-
-import javax.xml.bind.JAXBElement;
-import javax.xml.namespace.QName;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.docx4j.XmlUtils;
 import org.docx4j.openpackaging.io.SaveToZipFile;
 import org.docx4j.openpackaging.packages.WordprocessingMLPackage;
@@ -39,6 +31,13 @@ import org.docx4j.wml.P;
 import org.docx4j.wml.R;
 import org.docx4j.wml.RPr;
 import org.docx4j.wml.Text;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.xml.bind.JAXBElement;
+import javax.xml.namespace.QName;
+import java.util.ArrayList;
+import java.util.List;
 
 
 /**
@@ -84,7 +83,9 @@ public class VariablePrepare {
 		// approach (which wouldn't involve marshal/unmarshall, and 
 		// so should be more efficient).
 
-		log.info(XmlUtils.marshaltoString(wmlPackage.getMainDocumentPart().getJaxbElement(), true, true));
+        if(log.isInfoEnabled()) {
+            log.info(XmlUtils.marshaltoString(wmlPackage.getMainDocumentPart().getJaxbElement(), true, true));
+        }
 		
 		// Now clean up some more
 		org.docx4j.wml.Document wmlDocumentEl = wmlPackage.getMainDocumentPart().getJaxbElement();
@@ -94,8 +95,10 @@ public class VariablePrepare {
 			= new SingleTraversalUtilVisitorCallback(
 					new TraversalUtilParagraphVisitor());
 		paragraphVisitor.walkJAXBElements(body);
-		
-		log.info(XmlUtils.marshaltoString(wmlPackage.getMainDocumentPart().getJaxbElement(), true, true));
+
+        if(log.isInfoEnabled()) {
+            log.info(XmlUtils.marshaltoString(wmlPackage.getMainDocumentPart().getJaxbElement(), true, true));
+        }
 	}
 	
     private final static QName _RT_QNAME = new QName("http://schemas.openxmlformats.org/wordprocessingml/2006/main", "t");

--- a/src/main/java/org/docx4j/model/fields/FieldRef.java
+++ b/src/main/java/org/docx4j/model/fields/FieldRef.java
@@ -304,7 +304,9 @@ public class FieldRef {
 				log.error("Nested field " + nested.getFldName() );				
 				
 			} else {
-				log.error(XmlUtils.marshaltoString(instructions.get(0), true, true) );
+                if(log.isErrorEnabled()) {
+                    log.error(XmlUtils.marshaltoString(instructions.get(0), true, true));
+                }
 			}
 			return null;
 		}
@@ -368,8 +370,10 @@ public class FieldRef {
 					mergeFormat = Boolean.TRUE;
 				}
 			} else {
-				log.error("TODO: extract field name from " + o.getClass().getName() );
-				log.error(XmlUtils.marshaltoString(instructions.get(0), true, true) );				
+                if(log.isErrorEnabled()) {
+                    log.error("TODO: extract field name from " + o.getClass().getName());
+                    log.error(XmlUtils.marshaltoString(instructions.get(0), true, true));
+                }
 			}
 		}
 		return mergeFormat;

--- a/src/main/java/org/docx4j/model/fields/FieldUpdater.java
+++ b/src/main/java/org/docx4j/model/fields/FieldUpdater.java
@@ -1,12 +1,5 @@
 package org.docx4j.model.fields;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import javax.xml.transform.TransformerException;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.docx4j.TraversalUtil;
 import org.docx4j.XmlUtils;
 import org.docx4j.jaxb.Context;
@@ -22,6 +15,12 @@ import org.docx4j.wml.ContentAccessor;
 import org.docx4j.wml.P;
 import org.docx4j.wml.R;
 import org.docx4j.wml.Text;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.xml.transform.TransformerException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Refreshes the values of certain fields in the
@@ -271,8 +270,10 @@ public class FieldUpdater {
 		if (o instanceof Text) {
 			return ((Text)o).getValue();
 		} else {
-			log.error("TODO: extract field name from " + o.getClass().getName() );
-			log.error(XmlUtils.marshaltoString(instructions.get(0), true, true) );
+            if(log.isErrorEnabled()) {
+                log.error("TODO: extract field name from " + o.getClass().getName());
+                log.error(XmlUtils.marshaltoString(instructions.get(0), true, true));
+            }
 			return null;
 		}
 	}

--- a/src/main/java/org/docx4j/model/fields/FieldsPreprocessor.java
+++ b/src/main/java/org/docx4j/model/fields/FieldsPreprocessor.java
@@ -1,18 +1,5 @@
 package org.docx4j.model.fields;
 
-import java.io.IOException;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.NoSuchElementException;
-
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.Unmarshaller;
-import javax.xml.namespace.QName;
-import javax.xml.transform.Source;
-import javax.xml.transform.Templates;
-import javax.xml.transform.TransformerConfigurationException;
-import javax.xml.transform.stream.StreamSource;
-
 import org.docx4j.XmlUtils;
 import org.docx4j.jaxb.Context;
 import org.docx4j.openpackaging.exceptions.Docx4JException;
@@ -26,6 +13,18 @@ import org.docx4j.wml.STFldCharType;
 import org.docx4j.wml.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.Unmarshaller;
+import javax.xml.namespace.QName;
+import javax.xml.transform.Source;
+import javax.xml.transform.Templates;
+import javax.xml.transform.TransformerConfigurationException;
+import javax.xml.transform.stream.StreamSource;
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.NoSuchElementException;
 
 /**
  * This class puts fields into a "canonical" representation
@@ -149,8 +148,9 @@ public class FieldsPreprocessor {
 //		fieldRPr = null;
 		
 		stack = new LinkedList<FieldRef>();
-		
-		log.debug(XmlUtils.marshaltoString(p));
+		if(log.isDebugEnabled()) {
+            log.debug(XmlUtils.marshaltoString(p));
+        }
 		handleContent(p.getContent(), newP);
 
 		// log.debug(XmlUtils.marshaltoString(newP, true));
@@ -279,8 +279,10 @@ public class FieldsPreprocessor {
 		// note that the newR object persists between invocations of this method,
 		// so you have to be careful to actually add it to the docx 
 		// before re-creating it
-		
-		log.debug("\nInput run: \n " + XmlUtils.marshaltoString(existingRun, true, true));
+
+        if(log.isDebugEnabled()) {
+            log.debug("\nInput run: \n " + XmlUtils.marshaltoString(existingRun, true, true));
+        }
 		
 		for (Object o2 : existingRun.getContent() ) {
 			
@@ -339,7 +341,9 @@ public class FieldsPreprocessor {
 					newR.getContent().add(o2);
 					if (!newAttachPoint.getContent().contains(newR)) {
 						newAttachPoint.getContent().add(newR);
-						log.debug("-- attaching -->" + XmlUtils.marshaltoString(newR, true, true));
+                        if(log.isDebugEnabled()) {
+                            log.debug("-- attaching -->" + XmlUtils.marshaltoString(newR, true, true));
+                        }
 					}
 					
 					if ( fieldIsTopLevel() ) {
@@ -402,7 +406,9 @@ public class FieldsPreprocessor {
 							 */
 							if (!newAttachPoint.getContent().contains(newR)) {
 								newAttachPoint.getContent().add(newR);
-								log.debug("-- attaching -->" + XmlUtils.marshaltoString(newR, true, true));
+                                if(log.isDebugEnabled()) {
+                                    log.debug("-- attaching -->" + XmlUtils.marshaltoString(newR, true, true));
+                                }
 							}
 							newR = Context.getWmlObjectFactory().createR();						
 						}						
@@ -431,7 +437,9 @@ public class FieldsPreprocessor {
 													
 							if (!newAttachPoint.getContent().contains(newR)) {
 								newAttachPoint.getContent().add(newR);
-								log.debug("-- attaching -->" + XmlUtils.marshaltoString(newR, true, true));
+                                if(log.isDebugEnabled()) {
+                                    log.debug("-- attaching -->" + XmlUtils.marshaltoString(newR, true, true));
+                                }
 							}
 							
 						}					
@@ -444,7 +452,9 @@ public class FieldsPreprocessor {
 						}
 						if (!newAttachPoint.getContent().contains(newR)) { // test, since this is also done immediately before each loop ends
 							newAttachPoint.getContent().add(newR);
-							log.debug("-- attaching -->" + XmlUtils.marshaltoString(newR, true, true));
+                            if(log.isDebugEnabled()) {
+                                log.debug("-- attaching -->" + XmlUtils.marshaltoString(newR, true, true));
+                            }
 						}
 						
 						
@@ -476,7 +486,9 @@ public class FieldsPreprocessor {
 
 					if (!newAttachPoint.getContent().contains(newR)) {
 						newAttachPoint.getContent().add(newR);
-						log.debug("-- attaching -->" + XmlUtils.marshaltoString(newR, true, true));
+                        if(log.isDebugEnabled()) {
+                            log.debug("-- attaching -->" + XmlUtils.marshaltoString(newR, true, true));
+                        }
 					}
 				
 					newR = Context.getWmlObjectFactory().createR();						
@@ -540,7 +552,9 @@ public class FieldsPreprocessor {
 				
 				// we only want a single run between SEPARATOR and END,
 				// and we added that in the SEPARATE stuff above
-				log.debug("IGNORING " + XmlUtils.marshaltoString(o2, true, true));
+                if(log.isDebugEnabled()) {
+                    log.debug("IGNORING " + XmlUtils.marshaltoString(o2, true, true));
+                }
 				
 			} 
 

--- a/src/main/java/org/docx4j/model/fields/FldSimpleModel.java
+++ b/src/main/java/org/docx4j/model/fields/FldSimpleModel.java
@@ -1,16 +1,15 @@
 package org.docx4j.model.fields;
 
+import org.docx4j.XmlUtils;
+import org.docx4j.wml.CTSimpleField;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.w3c.dom.Node;
+
+import javax.xml.transform.TransformerException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
-import javax.xml.transform.TransformerException;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.docx4j.XmlUtils;
-import org.docx4j.wml.CTSimpleField;
-import org.w3c.dom.Node;
 
 /** Just a basic model for w:fldSimple that gets used in the 
  *  FldSimpleModelConverter for the conversion to pdf/html
@@ -30,7 +29,9 @@ public class FldSimpleModel {
 	
 	public void build(CTSimpleField fldSimple, Node content) throws TransformerException {
 		this.fldSimple = fldSimple;
-		log.debug("\n" + XmlUtils.marshaltoString(fldSimple, true, true));
+        if(log.isDebugEnabled()) {
+            log.debug("\n" + XmlUtils.marshaltoString(fldSimple, true, true));
+        }
 		this.content = content;
 		setupNameParameterString(fldSimple.getInstr());
 	}

--- a/src/main/java/org/docx4j/model/fields/merge/MailMerger.java
+++ b/src/main/java/org/docx4j/model/fields/merge/MailMerger.java
@@ -135,7 +135,9 @@ public class MailMerger {
 		
 		// create contents destined for the main document part
 		FieldsPreprocessor.complexifyFields(input.getMainDocumentPart() );
-		log.debug("complexified: " + XmlUtils.marshaltoString(input.getMainDocumentPart().getJaxbElement(), true));
+        if(log.isDebugEnabled()) {
+            log.debug("complexified: " + XmlUtils.marshaltoString(input.getMainDocumentPart().getJaxbElement(), true));
+        }
 		List<List<Object>> mdpResults = performOverList(input, input.getMainDocumentPart().getContent(), data, formTextFieldNames );
 
 		// headers/footers
@@ -159,8 +161,10 @@ public class MailMerger {
 				
 				JaxbXmlPart part = (JaxbXmlPart)input.getMainDocumentPart().getRelationshipsPart().getPart(relId);
 				FieldsPreprocessor.complexifyFields(part );
-				
-				log.debug("complexified: " + XmlUtils.marshaltoString(part.getJaxbElement(), true));
+
+                if(log.isDebugEnabled()) {
+                    log.debug("complexified: " + XmlUtils.marshaltoString(part.getJaxbElement(), true));
+                }
 				
 				hfTemplates.put(rel, part);
 			}
@@ -210,7 +214,9 @@ public class MailMerger {
 			// now inject the content
 			target.getMainDocumentPart().getContent().addAll(content);
 
-			log.debug(XmlUtils.marshaltoString(target.getMainDocumentPart().getJaxbElement(), true, true) );
+            if(log.isDebugEnabled()) {
+                log.debug(XmlUtils.marshaltoString(target.getMainDocumentPart().getJaxbElement(), true, true));
+            }
 			
 			// add sectPr to final paragraph
 			Object last = content.get( content.size()-1);
@@ -401,21 +407,27 @@ public class MailMerger {
 					
 					JaxbXmlPart part = (JaxbXmlPart)rp.getPart(r);
 
-					log.debug("\n\n BEFORE " + part.getPartName().getName() + "\n\n"
-							+ XmlUtils.marshaltoString(part.getJaxbElement(), true, true) + "\n");
+                    if(log.isDebugEnabled()) {
+                        log.debug("\n\n BEFORE " + part.getPartName().getName() + "\n\n"
+                                + XmlUtils.marshaltoString(part.getJaxbElement(), true, true) + "\n");
+                    }
 					
 					FieldsPreprocessor.complexifyFields(part );
-					
-					log.debug("\n\n COMPLEXIFIED " + part.getPartName().getName() + "\n\n"
-							+ XmlUtils.marshaltoString(part.getJaxbElement(), true, true) + "\n");
+
+                    if(log.isDebugEnabled()) {
+                        log.debug("\n\n COMPLEXIFIED " + part.getPartName().getName() + "\n\n"
+                                + XmlUtils.marshaltoString(part.getJaxbElement(), true, true) + "\n");
+                    }
 					
 					List<Object> results = performOnInstance(input,
 							((ContentAccessor)part).getContent(), data, formTextFieldNames );
 					((ContentAccessor)part).getContent().clear();
 					((ContentAccessor)part).getContent().addAll(results);
-					
-					log.debug("\n\n AFTER " + part.getPartName().getName() + "\n\n"
-							+ XmlUtils.marshaltoString(part.getJaxbElement(), true, true) + "\n");
+
+                    if(log.isDebugEnabled()) {
+                        log.debug("\n\n AFTER " + part.getPartName().getName() + "\n\n"
+                                + XmlUtils.marshaltoString(part.getJaxbElement(), true, true) + "\n");
+                    }
 					
 				}			
 			}		
@@ -550,8 +562,10 @@ public class MailMerger {
 					if (o instanceof Text) {
 						((Text)o).setValue("FORMTEXT");
 					} else {
-						log.error("TODO: set FORMTEXT in" + o.getClass().getName() );
-						log.error(XmlUtils.marshaltoString(instructions.get(0), true, true) );
+                        if(log.isErrorEnabled()) {
+                            log.error("TODO: set FORMTEXT in" + o.getClass().getName());
+                            log.error(XmlUtils.marshaltoString(instructions.get(0), true, true));
+                        }
 						continue;
 					}
 					
@@ -597,7 +611,9 @@ public class MailMerger {
 				// 2.8.1
 				index = ((ContentAccessor)p.getParent()).getContent().indexOf(p);
 				P newP = FieldsPreprocessor.canonicalise(p, fieldRefs);
-				log.debug("Canonicalised: " + XmlUtils.marshaltoString(newP, true, true));				
+                if(log.isDebugEnabled()) {
+                    log.debug("Canonicalised: " + XmlUtils.marshaltoString(newP, true, true));
+                }
 				((ContentAccessor)p.getParent()).getContent().set(index, newP);
 			} else if (p.getParent() instanceof java.util.List) {
 				// 3.0
@@ -609,7 +625,9 @@ public class MailMerger {
 				// 3.0.1
 				index = ((CTTextbox) p.getParent()).getTxbxContent().getContent().indexOf(p);
 				P newP = FieldsPreprocessor.canonicalise(p, fieldRefs);
-				log.debug("Canonicalised: "+ XmlUtils.marshaltoString(newP, true, true));
+                if(log.isDebugEnabled()) {
+                    log.debug("Canonicalised: " + XmlUtils.marshaltoString(newP, true, true));
+                }
 				((CTTextbox) p.getParent()).getTxbxContent().getContent().set(index, newP);
 			} else {
 				throw new Docx4JException("Unexpected parent: "+ p.getParent().getClass().getName());
@@ -682,8 +700,10 @@ public class MailMerger {
 		if (o instanceof Text) {
 			return ((Text)o).getValue();
 		} else {
-			log.error("TODO: extract field name from " + o.getClass().getName() );
-			log.error(XmlUtils.marshaltoString(instructions.get(0), true, true) );
+            if(log.isErrorEnabled()) {
+                log.error("TODO: extract field name from " + o.getClass().getName());
+                log.error(XmlUtils.marshaltoString(instructions.get(0), true, true));
+            }
 			return null;
 		}
 	}

--- a/src/main/java/org/docx4j/model/fields/merge/MailMergerWithNext.java
+++ b/src/main/java/org/docx4j/model/fields/merge/MailMergerWithNext.java
@@ -1,12 +1,5 @@
 package org.docx4j.model.fields.merge;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import javax.xml.transform.TransformerException;
-
 import org.apache.commons.lang.StringUtils;
 import org.docx4j.TraversalUtil;
 import org.docx4j.XmlUtils;
@@ -18,14 +11,17 @@ import org.docx4j.model.fields.FldSimpleModel;
 import org.docx4j.model.fields.FormattingSwitchHelper;
 import org.docx4j.openpackaging.exceptions.Docx4JException;
 import org.docx4j.openpackaging.packages.WordprocessingMLPackage;
-import org.docx4j.vml.CTTextbox;
 import org.docx4j.wml.Body;
-import org.docx4j.wml.ContentAccessor;
-import org.docx4j.wml.P;
 import org.docx4j.wml.R;
 import org.docx4j.wml.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.xml.transform.TransformerException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 public class MailMergerWithNext extends MailMerger {
 	
@@ -155,8 +151,10 @@ public class MailMergerWithNext extends MailMerger {
                     if (o instanceof Text) {
                         ((Text) o).setValue("FORMTEXT");
                     } else {
-                        log.error("TODO: set FORMTEXT in" + o.getClass().getName());
-                        log.error(XmlUtils.marshaltoString(instructions.get(0), true, true));
+                        if(log.isErrorEnabled()) {
+                            log.error("TODO: set FORMTEXT in" + o.getClass().getName());
+                            log.error(XmlUtils.marshaltoString(instructions.get(0), true, true));
+                        }
                         continue;
                     }
 

--- a/src/main/java/org/docx4j/model/images/WordXmlPictureE10.java
+++ b/src/main/java/org/docx4j/model/images/WordXmlPictureE10.java
@@ -136,7 +136,9 @@ public class WordXmlPictureE10 extends AbstractWordXmlPicture {
 	private void findImageData() {
 		
     	if (shape.getPathOrFormulasOrHandles()==null) {
-    		log.debug("Shape had no any: " + XmlUtils.marshaltoString(shape, true));
+            if(log.isDebugEnabled()) {
+                log.debug("Shape had no any: " + XmlUtils.marshaltoString(shape, true));
+            }
     	} else {
     		for (Object o : shape.getPathOrFormulasOrHandles() ) {
     			

--- a/src/main/java/org/docx4j/model/listnumbering/ListNumberingDefinition.java
+++ b/src/main/java/org/docx4j/model/listnumbering/ListNumberingDefinition.java
@@ -83,18 +83,18 @@
  */
 package org.docx4j.model.listnumbering;
 
-import java.math.BigInteger;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-
 import org.docx4j.XmlUtils;
 import org.docx4j.wml.Lvl;
 import org.docx4j.wml.Numbering;
 import org.docx4j.wml.Numbering.Num.LvlOverride.StartOverride;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.math.BigInteger;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Represents:
@@ -188,11 +188,15 @@ public class ListNumberingDefinition {
 				 * </w:lvlOverride>
 				 */
 				for (Numbering.Num.LvlOverride overrideNode : levelOverrideNodes) {
-					log.debug("found LvlOverride "
-							+ XmlUtils.marshaltoString(overrideNode, true));
+                    if(log.isDebugEnabled()) {
+                        log.debug("found LvlOverride "
+                                + XmlUtils.marshaltoString(overrideNode, true));
+                    }
 					
 					if (overrideNode.getIlvl() == null) {
-						log.warn("Missing @w:ilvl! " + XmlUtils.marshaltoString(overrideNode, true));
+                        if(log.isWarnEnabled()) {
+                            log.warn("Missing @w:ilvl! " + XmlUtils.marshaltoString(overrideNode, true));
+                        }
 					} else {
 						String overrideLevelId = overrideNode.getIlvl().toString(); 
 						log.debug(".. " + overrideLevelId);

--- a/src/main/java/org/docx4j/model/properties/PropertyFactory.java
+++ b/src/main/java/org/docx4j/model/properties/PropertyFactory.java
@@ -19,10 +19,6 @@
  */
 package org.docx4j.model.properties;
 
-import java.math.BigInteger;
-import java.util.ArrayList;
-import java.util.List;
-
 import org.docx4j.Docx4jProperties;
 import org.docx4j.XmlUtils;
 import org.docx4j.model.properties.paragraph.Bidi;
@@ -80,6 +76,10 @@ import org.docx4j.wml.TrPr;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.css.CSSValue;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
 
 public class PropertyFactory {
 	
@@ -443,7 +443,9 @@ public class PropertyFactory {
 		}
 		
 		if (pPr.getInd() != null) {
-			log.debug("Indent from ppr: " + XmlUtils.marshaltoString(pPr.getInd(),  true, true)) ; 
+            if(log.isDebugEnabled()) {
+                log.debug("Indent from ppr: " + XmlUtils.marshaltoString(pPr.getInd(), true, true));
+            }
 			properties.add(new Indent(pPr.getInd()));			
 		}
 		

--- a/src/main/java/org/docx4j/model/properties/paragraph/Indent.java
+++ b/src/main/java/org/docx4j/model/properties/paragraph/Indent.java
@@ -19,8 +19,6 @@
  */
 package org.docx4j.model.properties.paragraph;
 
-import java.math.BigInteger;
-
 import org.docx4j.UnitsOfMeasurement;
 import org.docx4j.XmlUtils;
 import org.docx4j.jaxb.Context;
@@ -32,6 +30,8 @@ import org.slf4j.LoggerFactory;
 import org.w3c.dom.Element;
 import org.w3c.dom.css.CSSPrimitiveValue;
 import org.w3c.dom.css.CSSValue;
+
+import java.math.BigInteger;
 
 public class Indent extends AbstractParagraphProperty {
 	
@@ -182,7 +182,9 @@ public class Indent extends AbstractParagraphProperty {
 
 		
 		if (left==null && firstline == null && hanging==null){
-			log.debug("What to do with " + XmlUtils.marshaltoString(this.getObject(), true, true));
+            if(log.isDebugEnabled()) {
+                log.debug("What to do with " + XmlUtils.marshaltoString(this.getObject(), true, true));
+            }
 			prop =  CSS_NULL;
 		} 
 		return prop;

--- a/src/main/java/org/docx4j/model/styles/BrokenStyleRemediator.java
+++ b/src/main/java/org/docx4j/model/styles/BrokenStyleRemediator.java
@@ -31,9 +31,11 @@ public class BrokenStyleRemediator {
     public static void remediate(Style s) {
     	
     	if (s.getStyleId()==null) {
-    		
-    		log.warn("Style is missing ID(!)");
-    		log.warn(XmlUtils.marshaltoString(s));
+
+            if(log.isWarnEnabled()) {
+                log.warn("Style is missing ID(!)");
+                log.warn(XmlUtils.marshaltoString(s));
+            }
     		
     		// Set the ID to the name
     		if (s.getName()!=null

--- a/src/main/java/org/docx4j/model/styles/StyleTree.java
+++ b/src/main/java/org/docx4j/model/styles/StyleTree.java
@@ -1,17 +1,17 @@
 package org.docx4j.model.styles;
 
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 import org.docx4j.XmlUtils;
 import org.docx4j.openpackaging.packages.WordprocessingMLPackage;
 import org.docx4j.wml.Style;
 import org.docx4j.wml.Styles;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Represent a style hierarchy as a tree.
@@ -72,7 +72,9 @@ public class StyleTree {
                 	log.warn("Couldn't find style: " + styleId);
                 	continue;
                 } else if (style.getType()==null) {
-                	log.warn("missing type: " + XmlUtils.marshaltoString(style)); 
+                    if(log.isWarnEnabled()) {
+                        log.warn("missing type: " + XmlUtils.marshaltoString(style));
+                    }
                 } else
         		// Is it a table style?
         		if (style.getType().equals("table")) {                

--- a/src/main/java/org/docx4j/model/styles/StyleUtil.java
+++ b/src/main/java/org/docx4j/model/styles/StyleUtil.java
@@ -19,12 +19,6 @@
  */
 package org.docx4j.model.styles;
 
-import java.math.BigInteger;
-import java.util.List;
-
-import javax.xml.bind.JAXBElement;
-import javax.xml.namespace.QName;
-
 import org.docx4j.XmlUtils;
 import org.docx4j.jaxb.Context;
 import org.docx4j.sharedtypes.STOnOff;
@@ -111,6 +105,11 @@ import org.docx4j.wml.U;
 import org.docx4j.wml.UnderlineEnumeration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.xml.bind.JAXBElement;
+import javax.xml.namespace.QName;
+import java.math.BigInteger;
+import java.util.List;
 
 /*
  *  @author Alberto Zerolo
@@ -1107,7 +1106,9 @@ public class StyleUtil {
 		else {
 
 			log.warn("style type is currently unknown or null");
-			log.debug(XmlUtils.marshaltoString(style));
+            if(log.isDebugEnabled()) {
+                log.debug(XmlUtils.marshaltoString(style));
+            }
 			
 			return isEmpty(style.getPPr()) &&
 					   isEmpty(style.getRPr()) &&

--- a/src/main/java/org/docx4j/openpackaging/parts/WordprocessingML/NumberingDefinitionsPart.java
+++ b/src/main/java/org/docx4j/openpackaging/parts/WordprocessingML/NumberingDefinitionsPart.java
@@ -21,12 +21,6 @@
 package org.docx4j.openpackaging.parts.WordprocessingML;
 
 
-import java.io.IOException;
-import java.math.BigInteger;
-import java.util.HashMap;
-
-import javax.xml.bind.JAXBException;
-
 import org.docx4j.XmlUtils;
 import org.docx4j.jaxb.Context;
 import org.docx4j.model.PropertyResolver;
@@ -52,6 +46,11 @@ import org.docx4j.wml.PPrBase.NumPr;
 import org.docx4j.wml.Style;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.xml.bind.JAXBException;
+import java.io.IOException;
+import java.math.BigInteger;
+import java.util.HashMap;
 
 
 
@@ -285,7 +284,9 @@ public final class NumberingDefinitionsPart extends JaxbXmlPartXPathAware<Number
 		if (numPr.getIlvl()!=null) ilvlString = numPr.getIlvl().getVal().toString();
 		
 		if (numPr.getNumId()==null) {
-			log.warn("numPr without numId: " + XmlUtils.marshaltoString(numPr, true, true));
+            if(log.isWarnEnabled()) {
+                log.warn("numPr without numId: " + XmlUtils.marshaltoString(numPr, true, true));
+            }
 						
 			return null;
 		} else {		

--- a/src/main/java/org/docx4j/openpackaging/parts/WordprocessingML/StyleDefinitionsPart.java
+++ b/src/main/java/org/docx4j/openpackaging/parts/WordprocessingML/StyleDefinitionsPart.java
@@ -20,14 +20,6 @@
 
 package org.docx4j.openpackaging.parts.WordprocessingML;
 
-import java.io.IOException;
-import java.math.BigInteger;
-import java.util.List;
-
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Unmarshaller;
-
 import org.docx4j.XmlUtils;
 import org.docx4j.jaxb.Context;
 import org.docx4j.model.styles.BrokenStyleRemediator;
@@ -47,6 +39,13 @@ import org.docx4j.wml.Style.BasedOn;
 import org.docx4j.wml.Styles;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Unmarshaller;
+import java.io.IOException;
+import java.math.BigInteger;
+import java.util.List;
 
 
 public final class StyleDefinitionsPart extends JaxbXmlPartXPathAware<Styles> {
@@ -238,9 +237,11 @@ public final class StyleDefinitionsPart extends JaxbXmlPartXPathAware<Styles> {
     		this.getJaxbElement().getStyle().add(styleDocDefaults);
     		
     	} else {
-    		
-    		log.debug("Found existing style named " + ROOT_NAME);
-    		log.debug(XmlUtils.marshaltoString(styleDocDefaults, true, true));
+
+            if(log.isDebugEnabled()) {
+                log.debug("Found existing style named " + ROOT_NAME);
+                log.debug(XmlUtils.marshaltoString(styleDocDefaults, true, true));
+            }
     		
         	// TODO: could be a name collision; some other app using that name :-(
     		// We could check whether normal is based on it (see towards end of this method)
@@ -363,10 +364,11 @@ public final class StyleDefinitionsPart extends JaxbXmlPartXPathAware<Styles> {
 		BasedOn based = Context.getWmlObjectFactory().createStyleBasedOn();
 		based.setVal(ROOT_NAME);		
 		normal.setBasedOn(based);
-		
-		log.debug("Set virtual style, id '" + styleDocDefaults.getStyleId() + "', name '"+ styleDocDefaults.getName().getVal() + "'");
-		
-		log.debug(XmlUtils.marshaltoString(styleDocDefaults, true, true));
+
+        if(log.isDebugEnabled()) {
+            log.debug("Set virtual style, id '" + styleDocDefaults.getStyleId() + "', name '" + styleDocDefaults.getName().getVal() + "'");
+            log.debug(XmlUtils.marshaltoString(styleDocDefaults, true, true));
+        }
 		
 		
     	

--- a/src/main/java/org/docx4j/utils/SingleTraversalUtilVisitorCallback.java
+++ b/src/main/java/org/docx4j/utils/SingleTraversalUtilVisitorCallback.java
@@ -1,10 +1,10 @@
 package org.docx4j.utils;
 
-import java.util.List;
-
 import org.docx4j.XmlUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.List;
 
 /** 
  * Use this if there is only a single object type (eg just P's)
@@ -36,9 +36,11 @@ public class SingleTraversalUtilVisitorCallback extends AbstractTraversalUtilVis
 			log.warn("visitorClass==null for some element with parent " + parent.getClass().getName() );
 			//log.warn(XmlUtils.marshaltoString(parent));
 		} else if (child==null) {
-			log.warn("child==null for some element with parent " + parent.getClass().getName() );
-			// eg <w:t/>
-			log.warn(XmlUtils.marshaltoString(parent));
+            if(log.isWarnEnabled()) {
+                log.warn("child==null for some element with parent " + parent.getClass().getName());
+                // eg <w:t/>
+                log.warn(XmlUtils.marshaltoString(parent));
+            }
 		} else if (visitorClass.isAssignableFrom(child.getClass())) {
 			visitor.apply(child, parent, siblings);
 		}


### PR DESCRIPTION
XmlUtils.marshalToString() is relatively expensive, and is called a lot from log.debug()-statements.

This code surrounds log.XXX() containing marshalToString() with log.isXXXEnabled()-checks.

When profiling pdf-generation from a large Word-file, this was one of the hotspots.