### PR TITLE
Localize date and number fields formatting.

### DIFF
--- a/src/main/java/org/docx4j/model/fields/FormattingSwitchHelper.java
+++ b/src/main/java/org/docx4j/model/fields/FormattingSwitchHelper.java
@@ -2,12 +2,14 @@ package org.docx4j.model.fields;
 
 import java.text.DateFormat;
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.slf4j.Logger;
@@ -120,7 +122,13 @@ public class FormattingSwitchHelper {
 	 * 
 	 */
 	
-	protected static final ThreadLocal<SimpleDateFormat> DATE_FORMATS = new ThreadLocal();
+	protected static final ThreadLocal<Map<String, SimpleDateFormat>> DATE_FORMATS = new ThreadLocal<Map<String, SimpleDateFormat>>(){
+	    protected Map<String, SimpleDateFormat> initialValue() {
+	        HashMap<String, SimpleDateFormat> hashMap = new HashMap<String, SimpleDateFormat>();
+	        hashMap.put(null, (SimpleDateFormat)SimpleDateFormat.getDateTimeInstance());
+			return hashMap;
+	    }
+	};
 	
 	/** Conversion of page number formats to fo as defined 
 	 * <ul>
@@ -215,7 +223,11 @@ public class FormattingSwitchHelper {
 	}
 	
 	public static String applyFormattingSwitch(WordprocessingMLPackage wmlPackage, FldSimpleModel model, String value) throws Docx4JException {
+		return applyFormattingSwitch(wmlPackage, model, value, null);
+	}
 
+
+	public static String applyFormattingSwitch(WordprocessingMLPackage wmlPackage, FldSimpleModel model, String value, String lang) throws Docx4JException {
 		// date-and-time-formatting-switch: \@ 
 		Date date = null;
 		try {
@@ -242,7 +254,7 @@ public class FormattingSwitchHelper {
 					// For =, today's date is used!
 					date = new Date();
 				}
-				value = formatDate(model, dtFormat, date);
+				value = formatDate(model, dtFormat, date, lang);
 			}
 			
 		} catch (FieldResultIsNotADateOrTimeException e) {
@@ -276,7 +288,7 @@ public class FormattingSwitchHelper {
 						return "!Syntax Error";
 					}
 					
-					value = formatNumber(model, nFormat, number );
+					value = formatNumber(model, nFormat, number, lang);
 
 	
 						// SPECIFICATION: If no numeric-formatting-switch is present, 
@@ -399,7 +411,7 @@ public class FormattingSwitchHelper {
 		}
 	}
 	
-	private static String formatNumber( FldSimpleModel model, String wordNumberPattern, double dub) 
+	private static String formatNumber( FldSimpleModel model, String wordNumberPattern, double dub, String lang) 
 		throws FieldFormattingException {
 
 
@@ -616,7 +628,11 @@ public class FormattingSwitchHelper {
 		
 		DecimalFormat formatter = null;
 		try {
-			formatter = new DecimalFormat(javaFormatter);
+			if(lang != null){
+				formatter = new DecimalFormat(javaFormatter, new DecimalFormatSymbols(Locale.forLanguageTag(lang)));
+			} else {
+				formatter = new DecimalFormat(javaFormatter);
+			}
 		} catch (java.lang.IllegalArgumentException iae) {
 			// Malformed pattern
 			throw new FieldFormattingException(iae.getMessage() + " from " + wordNumberPattern);
@@ -840,10 +856,13 @@ public class FormattingSwitchHelper {
 	}
 
 	public static String formatDate(FldSimpleModel model, String format, Date date) {
-		
+		return formatDate(model, format, date, null);
+	}
+	
+	private static String formatDate(FldSimpleModel model, String format, Date date, String lang) {
 		DateFormat dateFormat = null;
 		if ((format != null) && (format.length() > 0)) {
-			SimpleDateFormat simpleDateFormat = getSimpleDateFormat();
+			SimpleDateFormat simpleDateFormat = getSimpleDateFormat(lang);
 			simpleDateFormat.applyPattern(convertDatePattern(format));
 			dateFormat = simpleDateFormat;
 		}
@@ -919,12 +938,19 @@ public class FormattingSwitchHelper {
 		return -1;
 	}
 	
-	private static SimpleDateFormat getSimpleDateFormat() {
-	SimpleDateFormat ret = DATE_FORMATS.get();
-		if (ret == null) {
-			ret = (SimpleDateFormat)SimpleDateFormat.getDateTimeInstance();
-			DATE_FORMATS.set(ret);
+	/**
+	 * @param language abbreviation like "fr-CA", 
+	 * @return SimpleDateFormat instance for specified language
+	 * if null will @return SimpleDateFormat.getDateTimeInstance()
+	 */
+	private static SimpleDateFormat getSimpleDateFormat(String lang) {
+		Map<String, SimpleDateFormat> dateFormatsMap = DATE_FORMATS.get();
+		SimpleDateFormat dateFormat = dateFormatsMap.get(lang);
+		if (dateFormat == null) {
+			dateFormat = (SimpleDateFormat)SimpleDateFormat.getDateTimeInstance(DateFormat.DEFAULT, 0, Locale.forLanguageTag(lang));
+			dateFormatsMap.put(lang, dateFormat);
 		}
-		return ret;
+		return dateFormat;
 	}
+	
 }

--- a/src/main/java/org/docx4j/model/fields/merge/MailMerger.java
+++ b/src/main/java/org/docx4j/model/fields/merge/MailMerger.java
@@ -46,12 +46,14 @@ import org.docx4j.wml.CTFFData;
 import org.docx4j.wml.CTFFName;
 import org.docx4j.wml.CTFFTextInput;
 import org.docx4j.wml.CTFFTextType;
+import org.docx4j.wml.CTLanguage;
 import org.docx4j.wml.CTPageNumber;
 import org.docx4j.wml.CTRel;
 import org.docx4j.wml.ContentAccessor;
 import org.docx4j.wml.ObjectFactory;
 import org.docx4j.wml.P;
 import org.docx4j.wml.R;
+import org.docx4j.wml.RPr;
 import org.docx4j.wml.STFFTextType;
 import org.docx4j.wml.SectPr;
 import org.docx4j.wml.Text;
@@ -497,6 +499,7 @@ public class MailMerger {
 			if ( fr.getFldName().equals("MERGEFIELD") ) {
 				
 				String instr = extractInstr(fr.getInstructions() );
+				String lang = extractLang(fr.getResultsSlot());
 				String datafieldName = getDatafieldNameFromInstr(instr);
 				String val = datamap.get( new DataFieldName(datafieldName));
 				String gFormat = null; // required only for FORMTEXT conversion
@@ -521,7 +524,7 @@ public class MailMerger {
 					FldSimpleModel fsm = new FldSimpleModel();
 					try {
 						fsm.build(instr);
-						val = FormattingSwitchHelper.applyFormattingSwitch(input, fsm, val);
+						val = FormattingSwitchHelper.applyFormattingSwitch(input, fsm, val, lang);
 						
 						gFormat = FormattingSwitchHelper.findFirstSwitchValue("\\*", fsm.getFldParameters(), true);
 						// Solely for potential use in OutputField.AS_FORMTEXT_REGULAR
@@ -596,6 +599,25 @@ public class MailMerger {
 		
 		return shellClone.getContent();
 
+	}
+
+	/**
+	 * Extract language information from run parameters to be able to 
+	 * format month, day, week, etc. in its abbreviated form according to the 
+	 * language specified by the lang element on the run containing the field instructions.
+	 * Also it will be used to use language specific <code>DecimalFormatSymbols</code> for number formating
+	 * @param R Run
+	 * @returns string language like "fr-CA" abbreviation or null
+	 */
+	private static String extractLang(R resultsSlot) {
+		RPr rPr = resultsSlot.getRPr();
+		if(rPr != null){
+			CTLanguage lang = rPr.getLang();
+			if(lang != null){
+				return lang.getVal();
+			}
+		}
+		return null;
 	}
 
 	/**


### PR DESCRIPTION
Use Locale according to the language specified by the lang element on
the run containing the field instructions.