### PR TITLE
Fix for Issue #183: MailMerge and totally unrelated nested fields

### DIFF
--- a/src/main/java/org/docx4j/model/fields/FieldRef.java
+++ b/src/main/java/org/docx4j/model/fields/FieldRef.java
@@ -301,8 +301,7 @@ public class FieldRef {
 			if (o instanceof FieldRef) {
 				// contains a nested field?!
 				FieldRef nested = (FieldRef)o;
-				log.error("Nested field " + nested.getFldName() );				
-				
+				log.error("Nested field detected");
 			} else {
                 if(log.isErrorEnabled()) {
                     log.error(XmlUtils.marshaltoString(instructions.get(0), true, true));
@@ -310,7 +309,15 @@ public class FieldRef {
 			}
 			return null;
 		}
-	}	
+	}
+
+	/**
+	 * Check whether this field is nested
+	 */
+	public boolean isNestedField() {
+		Object o = XmlUtils.unwrap(instructions.get(0));
+		return o instanceof FieldRef;
+	}
 	
 	private ContentAccessor parent;
 	public ContentAccessor getParent() {

--- a/src/main/java/org/docx4j/model/fields/FieldsPreprocessor.java
+++ b/src/main/java/org/docx4j/model/fields/FieldsPreprocessor.java
@@ -252,6 +252,8 @@ public class FieldsPreprocessor {
 		
 		if (fieldRef.isLock()) return true;
 		
+		if (fieldRef.isNestedField())
+			return true;
 		
 		String fldName = fieldRef.getFldName();
 		if (fldName==null) return true;

--- a/src/main/java/org/docx4j/model/fields/merge/MailMerger.java
+++ b/src/main/java/org/docx4j/model/fields/merge/MailMerger.java
@@ -493,7 +493,9 @@ public class MailMerger {
 		
 		// Populate
 		for (FieldRef fr : fieldRefs) {
-			
+			if (fr.isNestedField())
+				continue;
+
 			if ( fr.getFldName().equals("MERGEFIELD") ) {
 				
 				String instr = extractInstr(fr.getInstructions() );


### PR DESCRIPTION
These changes for MailMerge ignore and preserve nested fields
that may or may not contain MERGEFIELDs.

Nested fields in an imported docx can cause a stack overflow
in FieldRef.java:304 (which logs the detection of nested fields...).