### PR TITLE
tblCaption functionality & filter.xslt fixed

### DIFF
--- a/src/main/java/org/docx4j/openpackaging/packages/filter.xslt
+++ b/src/main/java/org/docx4j/openpackaging/packages/filter.xslt
@@ -28,7 +28,7 @@
   <xsl:copy>
     <xsl:apply-templates select="@*|node()"/>
   </xsl:copy>
-</xsl:template
+</xsl:template>
 
 <xsl:template match="w:lastRenderedPageBreak">
 	

--- a/src/main/java/org/docx4j/wml/CTTblPrBase.java
+++ b/src/main/java/org/docx4j/wml/CTTblPrBase.java
@@ -115,7 +115,8 @@ import javax.xml.bind.annotation.XmlType;
     "shd",
     "tblLayout",
     "tblCellMar",
-    "tblLook"
+    "tblLook",
+	"tblCaption"
 })
 public class CTTblPrBase implements Child
 {
@@ -135,6 +136,7 @@ public class CTTblPrBase implements Child
     protected CTTblLayoutType tblLayout;
     protected CTTblCellMar tblCellMar;
     protected CTTblLook tblLook;
+	protected CTString tblCaption;
     @XmlTransient
     private Object parent;
 
@@ -496,6 +498,30 @@ public class CTTblPrBase implements Child
      */
     public void setTblLook(CTTblLook value) {
         this.tblLook = value;
+    }
+	
+	/**
+	 * Gets the value of the tblCaption property.
+	 *
+	 * @return
+	 *     possible object is
+     *     {@link CTString }
+     *     
+     */
+	public CTString getTblCaption() {
+		return tblCaption;
+	}
+	
+	/**
+     * Sets the value of the tblCaption property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link CTString }
+     *     
+     */
+    public void setTblCaption(CTString value) {
+        this.tblCaption = value;
     }
 
     /**

--- a/src/main/java/org/docx4j/wml/CTTblPrExBase.java
+++ b/src/main/java/org/docx4j/wml/CTTblPrExBase.java
@@ -67,7 +67,8 @@ import javax.xml.bind.annotation.XmlType;
     "shd",
     "tblLayout",
     "tblCellMar",
-    "tblLook"
+    "tblLook",
+	"tblCaption"
 })
 public class CTTblPrExBase implements Child
 {
@@ -81,6 +82,7 @@ public class CTTblPrExBase implements Child
     protected CTTblLayoutType tblLayout;
     protected CTTblCellMar tblCellMar;
     protected CTTblLook tblLook;
+	protected CTString tblCaption;
     @XmlTransient
     private Object parent;
 
@@ -300,6 +302,30 @@ public class CTTblPrExBase implements Child
         this.tblLook = value;
     }
 
+	/**
+     * Gets the value of the tblCaption property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link CTString }
+     *     
+     */
+    public CTString getTblCaption() {
+        return tblCaption;
+    }
+
+    /**
+     * Sets the value of the tblCaption property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link CTString }
+     *     
+     */
+    public void setTblCaption(CTString value) {
+        this.tblCaption = value;
+    }
+	
     /**
      * Gets the parent object in the object tree representing the unmarshalled xml document.
      * 


### PR DESCRIPTION
Added getter/setter for tblCaption, child element of tblPr element, which is part of the updated ECMA-376 Standard. Added missing ">" to line 31 of filter.xslt.