### PR TITLE
remove bookmarks when doing 'prepare'

### DIFF
--- a/src/main/java/org/docx4j/model/datastorage/migration/VariablePrepare.java
+++ b/src/main/java/org/docx4j/model/datastorage/migration/VariablePrepare.java
@@ -76,6 +76,7 @@ public class VariablePrepare {
 		filterSettings.setRemoveProofErrors(true);
 		filterSettings.setRemoveContentControls(true);
 		filterSettings.setRemoveRsids(true);
+		filterSettings.setRemoveBookmarks(true);
 		wmlPackage.filter(filterSettings);
 		// Note the filter is deprecated, since its questionable whether this
 		// is important enough to live in WordprocessingMLPackage,


### PR DESCRIPTION
Otherwise it will fail when using variableReplace in a docx with bookmarks