### PR TITLE
Improvement in type of map of variableReplace method of JaxbXmlPart c…

### DIFF
--- a/src/main/java/org/docx4j/openpackaging/parts/JaxbXmlPart.java
+++ b/src/main/java/org/docx4j/openpackaging/parts/JaxbXmlPart.java
@@ -244,7 +244,7 @@ public abstract class JaxbXmlPart<E> /* used directly only by DocProps parts, Re
 	 * 
 	 * @since 3.0.0
 	 */
-	public void variableReplace(java.util.HashMap<String, String> mappings) throws JAXBException, Docx4JException {
+	public void variableReplace(java.util.Map<String, String> mappings) throws JAXBException, Docx4JException {
 		
 		// Get the contents as a string
 		String wmlTemplateString = null;


### PR DESCRIPTION
…lass

Hi everyone, i was using the docx4j and in JaxbXmlPart and i found a small gap in code, the variableReplace method recieve java.util.HashMap<String, String> mappings but the correct type is Map because other methods than using the object mappings had a Map in signature of method.

It's my first pull request, if had some mistakes, my apologizes