### PR TITLE
@XmlRootElement, Namespace and ContentType for Chartsheets

### DIFF
--- a/src/main/java/org/docx4j/openpackaging/contenttype/ContentTypes.java
+++ b/src/main/java/org/docx4j/openpackaging/contenttype/ContentTypes.java
@@ -291,6 +291,10 @@ public class ContentTypes {
 	// PartName="/xl/worksheets/sheet1.xml"
 	public final static String SPREADSHEETML_WORKSHEET = 
 		"application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml";
+
+	// PartName="/xl/chartsheets/sheet1.xml"
+	public final static String SPREADSHEETML_CHARTSHEET = 
+		"application/vnd.openxmlformats-officedocument.spreadsheetml.chartsheet+xml";
 	
 	// PartName="/xl/calcChain.xml"
 	public final static String SPREADSHEETML_CALC_CHAIN = 

--- a/src/main/java/org/docx4j/openpackaging/parts/relationships/Namespaces.java
+++ b/src/main/java/org/docx4j/openpackaging/parts/relationships/Namespaces.java
@@ -257,6 +257,10 @@ public class Namespaces {
 	public final static String SPREADSHEETML_WORKSHEET = 
 		"http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet";
 
+	// chartsheets/sheet1.xml
+	public final static String SPREADSHEETML_CHARTSHEET = 
+		"http://schemas.openxmlformats.org/officeDocument/2006/relationships/chartsheet";
+
 	// ../printerSettings/printerSettings1.bin
 	public final static String SPREADSHEETML_PRINTER_SETTINGS = 
 		"http://schemas.openxmlformats.org/officeDocument/2006/relationships/printerSettings";

--- a/src/xlsx4j/java/org/docx4j/openpackaging/parts/SpreadsheetML/ChartsheetPart.java
+++ b/src/xlsx4j/java/org/docx4j/openpackaging/parts/SpreadsheetML/ChartsheetPart.java
@@ -1,0 +1,68 @@
+package org.docx4j.openpackaging.parts.SpreadsheetML;
+
+import javax.xml.bind.JAXBException;
+
+import org.docx4j.openpackaging.exceptions.InvalidFormatException;
+import org.docx4j.openpackaging.packages.SpreadsheetMLPackage;
+import org.docx4j.openpackaging.parts.PartName;
+import org.docx4j.openpackaging.parts.relationships.Namespaces;
+import org.xlsx4j.sml.CTChartsheet;
+
+public class ChartsheetPart extends JaxbSmlPart<CTChartsheet> {
+	
+	public ChartsheetPart(PartName partName) throws InvalidFormatException {
+		super(partName);
+		init();
+	}
+
+	public ChartsheetPart() throws InvalidFormatException {
+		super(new PartName("/xl/chartsheets/sheet1.xml"));
+		init();
+	}
+	
+	public void init() {
+				
+		// Used if this Part is added to [Content_Types].xml 
+		setContentType(new  org.docx4j.openpackaging.contenttype.ContentType( 
+				org.docx4j.openpackaging.contenttype.ContentTypes.SPREADSHEETML_CHARTSHEET));
+
+		// Used when this Part is added to a rels 
+		setRelationshipType(Namespaces.SPREADSHEETML_CHARTSHEET);
+		
+	}
+	
+	@Override
+	public void setJaxbElement(CTChartsheet jaxbElement) {
+		super.setJaxbElement(jaxbElement);
+		jaxbElement.setParent(this); // if you create a new ChartsheetPart
+	}
+	
+	@Override
+    public CTChartsheet unmarshal( java.io.InputStream is ) throws JAXBException {
+		
+		CTChartsheet w = super.unmarshal(is);
+		w.setParent(this); // workaround for JAXB in Java 8 setting parent to JAXBElement!
+		return w;
+	}
+	
+	@Override
+    public CTChartsheet unmarshal(org.w3c.dom.Element el) throws JAXBException {
+
+		CTChartsheet w = super.unmarshal(el);
+		w.setParent(this); // presume JAXB gets in wrong here too
+		return w;
+		
+	}
+	
+	/**
+	 * Get the WorkbookPart.
+	 * 
+	 * @return
+	 * @since 3.3.3
+	 */
+	public WorkbookPart getWorkbookPart() {
+		
+		return ((SpreadsheetMLPackage)this.getPackage()).getWorkbookPart();
+		
+	}
+}

--- a/src/xlsx4j/java/org/xlsx4j/sml/CTChartsheet.java
+++ b/src/xlsx4j/java/org/xlsx4j/sml/CTChartsheet.java
@@ -23,8 +23,10 @@ import javax.xml.bind.Unmarshaller;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
 import javax.xml.bind.annotation.XmlType;
+
 import org.jvnet.jaxb2_commons.ppp.Child;
 
 
@@ -77,6 +79,7 @@ import org.jvnet.jaxb2_commons.ppp.Child;
     "webPublishItems",
     "extLst"
 })
+@XmlRootElement(name = "chartsheet")
 public class CTChartsheet implements Child
 {
 


### PR DESCRIPTION
Xlsx4j doesn’t support chartsheets (custom sheet that displays a single chart without any cells) out-of-the-box. To provide this functionality I added XmlRootElement to CTChartsheet. Furthermore, I copied and modified WorksheetPart to ChartsheetPart and included the required namespace and content type. 