### PR TITLE
Fixed the licenses in comments for merged TOC from docx4j enterprise …

### DIFF
--- a/src/main/java/org/docx4j/toc/switches/AbstractSwitch.java
+++ b/src/main/java/org/docx4j/toc/switches/AbstractSwitch.java
@@ -1,22 +1,21 @@
 /*
- *  Copyright 2013, Plutext Pty Ltd.
- *   
- *  This file is part of the Commercial Edition of docx4j,
- *  which is licensed under the Plutext Commercial License (the "License"); 
- *  you may not use this file except in compliance with the License. 
- *  
- *  In particular, this source code is CONFIDENTIAL, and you must ensure it
- *  stays that way. 
+ *  Copyright 2013-2016, Plutext Pty Ltd.
  *
- *  You may obtain a copy of the License at 
- *
- *      http://www.plutext.com/license/Plutext_Commercial_License.pdf 
- *
- *  Unless required by applicable law or agreed to in writing, software 
- *  distributed under the License is distributed on an "AS IS" BASIS, 
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- *  See the License for the specific language governing permissions and 
- *  limitations under the License.
+ *  This file is part of docx4j.
+
+    docx4j is licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
  */
 package org.docx4j.toc.switches;
 

--- a/src/main/java/org/docx4j/toc/switches/HSwitch.java
+++ b/src/main/java/org/docx4j/toc/switches/HSwitch.java
@@ -1,22 +1,21 @@
 /*
- *  Copyright 2013, Plutext Pty Ltd.
- *   
- *  This file is part of the Commercial Edition of docx4j,
- *  which is licensed under the Plutext Commercial License (the "License"); 
- *  you may not use this file except in compliance with the License. 
- *  
- *  In particular, this source code is CONFIDENTIAL, and you must ensure it
- *  stays that way. 
+ *  Copyright 2013-2016, Plutext Pty Ltd.
  *
- *  You may obtain a copy of the License at 
- *
- *      http://www.plutext.com/license/Plutext_Commercial_License.pdf 
- *
- *  Unless required by applicable law or agreed to in writing, software 
- *  distributed under the License is distributed on an "AS IS" BASIS, 
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- *  See the License for the specific language governing permissions and 
- *  limitations under the License.
+ *  This file is part of docx4j.
+
+    docx4j is licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
  */
 package org.docx4j.toc.switches;
 

--- a/src/main/java/org/docx4j/toc/switches/NSwitch.java
+++ b/src/main/java/org/docx4j/toc/switches/NSwitch.java
@@ -1,22 +1,21 @@
 /*
- *  Copyright 2013, Plutext Pty Ltd.
- *   
- *  This file is part of the Commercial Edition of docx4j,
- *  which is licensed under the Plutext Commercial License (the "License"); 
- *  you may not use this file except in compliance with the License. 
- *  
- *  In particular, this source code is CONFIDENTIAL, and you must ensure it
- *  stays that way. 
+ *  Copyright 2013-2016, Plutext Pty Ltd.
  *
- *  You may obtain a copy of the License at 
- *
- *      http://www.plutext.com/license/Plutext_Commercial_License.pdf 
- *
- *  Unless required by applicable law or agreed to in writing, software 
- *  distributed under the License is distributed on an "AS IS" BASIS, 
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- *  See the License for the specific language governing permissions and 
- *  limitations under the License.
+ *  This file is part of docx4j.
+
+    docx4j is licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
  */
 package org.docx4j.toc.switches;
 

--- a/src/main/java/org/docx4j/toc/switches/OSwitch.java
+++ b/src/main/java/org/docx4j/toc/switches/OSwitch.java
@@ -1,22 +1,21 @@
 /*
- *  Copyright 2013, Plutext Pty Ltd.
- *   
- *  This file is part of the Commercial Edition of docx4j,
- *  which is licensed under the Plutext Commercial License (the "License"); 
- *  you may not use this file except in compliance with the License. 
- *  
- *  In particular, this source code is CONFIDENTIAL, and you must ensure it
- *  stays that way. 
+ *  Copyright 2013-2016, Plutext Pty Ltd.
  *
- *  You may obtain a copy of the License at 
- *
- *      http://www.plutext.com/license/Plutext_Commercial_License.pdf 
- *
- *  Unless required by applicable law or agreed to in writing, software 
- *  distributed under the License is distributed on an "AS IS" BASIS, 
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- *  See the License for the specific language governing permissions and 
- *  limitations under the License.
+ *  This file is part of docx4j.
+
+    docx4j is licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
  */
 package org.docx4j.toc.switches;
 

--- a/src/main/java/org/docx4j/toc/switches/SwitchInterface.java
+++ b/src/main/java/org/docx4j/toc/switches/SwitchInterface.java
@@ -1,22 +1,21 @@
 /*
- *  Copyright 2013, Plutext Pty Ltd.
- *   
- *  This file is part of the Commercial Edition of docx4j,
- *  which is licensed under the Plutext Commercial License (the "License"); 
- *  you may not use this file except in compliance with the License. 
- *  
- *  In particular, this source code is CONFIDENTIAL, and you must ensure it
- *  stays that way. 
+ *  Copyright 2013-2016, Plutext Pty Ltd.
  *
- *  You may obtain a copy of the License at 
- *
- *      http://www.plutext.com/license/Plutext_Commercial_License.pdf 
- *
- *  Unless required by applicable law or agreed to in writing, software 
- *  distributed under the License is distributed on an "AS IS" BASIS, 
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- *  See the License for the specific language governing permissions and 
- *  limitations under the License.
+ *  This file is part of docx4j.
+
+    docx4j is licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
  */
 package org.docx4j.toc.switches;
 

--- a/src/main/java/org/docx4j/toc/switches/SwitchProcessor.java
+++ b/src/main/java/org/docx4j/toc/switches/SwitchProcessor.java
@@ -1,22 +1,21 @@
 /*
- *  Copyright 2013, Plutext Pty Ltd.
- *   
- *  This file is part of the Commercial Edition of docx4j,
- *  which is licensed under the Plutext Commercial License (the "License"); 
- *  you may not use this file except in compliance with the License. 
- *  
- *  In particular, this source code is CONFIDENTIAL, and you must ensure it
- *  stays that way. 
+ *  Copyright 2013-2016, Plutext Pty Ltd.
  *
- *  You may obtain a copy of the License at 
- *
- *      http://www.plutext.com/license/Plutext_Commercial_License.pdf 
- *
- *  Unless required by applicable law or agreed to in writing, software 
- *  distributed under the License is distributed on an "AS IS" BASIS, 
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- *  See the License for the specific language governing permissions and 
- *  limitations under the License.
+ *  This file is part of docx4j.
+
+    docx4j is licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
  */
 package org.docx4j.toc.switches;
 

--- a/src/main/java/org/docx4j/toc/switches/SwitchesFactory.java
+++ b/src/main/java/org/docx4j/toc/switches/SwitchesFactory.java
@@ -1,22 +1,21 @@
 /*
- *  Copyright 2013, Plutext Pty Ltd.
- *   
- *  This file is part of the Commercial Edition of docx4j,
- *  which is licensed under the Plutext Commercial License (the "License"); 
- *  you may not use this file except in compliance with the License. 
- *  
- *  In particular, this source code is CONFIDENTIAL, and you must ensure it
- *  stays that way. 
+ *  Copyright 2013-2016, Plutext Pty Ltd.
  *
- *  You may obtain a copy of the License at 
- *
- *      http://www.plutext.com/license/Plutext_Commercial_License.pdf 
- *
- *  Unless required by applicable law or agreed to in writing, software 
- *  distributed under the License is distributed on an "AS IS" BASIS, 
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- *  See the License for the specific language governing permissions and 
- *  limitations under the License.
+ *  This file is part of docx4j.
+
+    docx4j is licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
  */
 package org.docx4j.toc.switches;
 

--- a/src/main/java/org/docx4j/toc/switches/TSwitch.java
+++ b/src/main/java/org/docx4j/toc/switches/TSwitch.java
@@ -1,22 +1,21 @@
 /*
- *  Copyright 2013, Plutext Pty Ltd.
- *   
- *  This file is part of the Commercial Edition of docx4j,
- *  which is licensed under the Plutext Commercial License (the "License"); 
- *  you may not use this file except in compliance with the License. 
- *  
- *  In particular, this source code is CONFIDENTIAL, and you must ensure it
- *  stays that way. 
+ *  Copyright 2013-2016, Plutext Pty Ltd.
  *
- *  You may obtain a copy of the License at 
- *
- *      http://www.plutext.com/license/Plutext_Commercial_License.pdf 
- *
- *  Unless required by applicable law or agreed to in writing, software 
- *  distributed under the License is distributed on an "AS IS" BASIS, 
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- *  See the License for the specific language governing permissions and 
- *  limitations under the License.
+ *  This file is part of docx4j.
+
+    docx4j is licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
  */
 package org.docx4j.toc.switches;
 

--- a/src/main/java/org/docx4j/toc/switches/USwitch.java
+++ b/src/main/java/org/docx4j/toc/switches/USwitch.java
@@ -1,22 +1,21 @@
 /*
- *  Copyright 2013, Plutext Pty Ltd.
- *   
- *  This file is part of the Commercial Edition of docx4j,
- *  which is licensed under the Plutext Commercial License (the "License"); 
- *  you may not use this file except in compliance with the License. 
- *  
- *  In particular, this source code is CONFIDENTIAL, and you must ensure it
- *  stays that way. 
+ *  Copyright 2013-2016, Plutext Pty Ltd.
  *
- *  You may obtain a copy of the License at 
- *
- *      http://www.plutext.com/license/Plutext_Commercial_License.pdf 
- *
- *  Unless required by applicable law or agreed to in writing, software 
- *  distributed under the License is distributed on an "AS IS" BASIS, 
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
- *  See the License for the specific language governing permissions and 
- *  limitations under the License.
+ *  This file is part of docx4j.
+
+    docx4j is licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
  */
 package org.docx4j.toc.switches;
 


### PR DESCRIPTION
…to community edition

Pull request created as previously discussed over email. The files contained commercial licenses, that were inappropriate for the community edition of docx4j.