### PR TITLE
SDT bind and removal extensions for Footnotes and Endnotes

### DIFF
--- a/src/main/java/org/docx4j/Docx4J.java
+++ b/src/main/java/org/docx4j/Docx4J.java
@@ -497,17 +497,9 @@ public class Docx4J {
 	}
 
 	protected static void removeSDTs(WordprocessingMLPackage wmlPackage)throws Docx4JException {
-	RemovalHandler removalHandler;
-	removalHandler = new RemovalHandler();
-	removalHandler.removeSDTs(wmlPackage.getMainDocumentPart(), RemovalHandler.Quantifier.ALL, (String[])null);
-		for (Part part:wmlPackage.getParts().getParts().values()) {
-			if (part instanceof HeaderPart) {
-				removalHandler.removeSDTs((HeaderPart)part, RemovalHandler.Quantifier.ALL, (String[])null);
-			}
-			else if (part instanceof FooterPart) {
-				removalHandler.removeSDTs((FooterPart)part, RemovalHandler.Quantifier.ALL, (String[])null);
-			}
-		}
+	    RemovalHandler removalHandler;
+	    removalHandler = new RemovalHandler();
+	    removalHandler.removeSDTs(wmlPackage, RemovalHandler.Quantifier.ALL, (String[])null);
 	}
 
 	protected static void removeDefinedCustomXmlParts(WordprocessingMLPackage wmlPackage, CustomXmlDataStoragePart customXmlDataStoragePart) {

--- a/src/main/java/org/docx4j/model/datastorage/BindingHandler.java
+++ b/src/main/java/org/docx4j/model/datastorage/BindingHandler.java
@@ -32,7 +32,9 @@ import org.docx4j.openpackaging.exceptions.Docx4JException;
 import org.docx4j.openpackaging.packages.WordprocessingMLPackage;
 import org.docx4j.openpackaging.parts.CustomXmlPart;
 import org.docx4j.openpackaging.parts.JaxbXmlPart;
+import org.docx4j.openpackaging.parts.WordprocessingML.EndnotesPart;
 import org.docx4j.openpackaging.parts.WordprocessingML.FooterPart;
+import org.docx4j.openpackaging.parts.WordprocessingML.FootnotesPart;
 import org.docx4j.openpackaging.parts.WordprocessingML.HeaderPart;
 import org.docx4j.openpackaging.parts.opendope.XPathsPart;
 import org.docx4j.openpackaging.parts.relationships.Namespaces;
@@ -202,7 +204,12 @@ public class BindingHandler {
 					applyBindings((HeaderPart) rp.getPart(r));
 				} else if (r.getType().equals(Namespaces.FOOTER)) {
 					applyBindings((FooterPart) rp.getPart(r));
-				}
+                } else if (r.getType().equals(Namespaces.FOOTNOTES)) {
+                    applyBindings((FootnotesPart) rp.getPart(r));
+                } else if (r.getType().equals(Namespaces.ENDNOTES)) {
+                    applyBindings((EndnotesPart) rp.getPart(r));
+                }
+
 			}
 		}
 		

--- a/src/main/java/org/docx4j/model/datastorage/OpenDoPEHandler.java
+++ b/src/main/java/org/docx4j/model/datastorage/OpenDoPEHandler.java
@@ -50,7 +50,9 @@ import org.docx4j.openpackaging.parts.CustomXmlDataStoragePart;
 import org.docx4j.openpackaging.parts.CustomXmlPart;
 import org.docx4j.openpackaging.parts.PartName;
 import org.docx4j.openpackaging.parts.WordprocessingML.AlternativeFormatInputPart;
+import org.docx4j.openpackaging.parts.WordprocessingML.EndnotesPart;
 import org.docx4j.openpackaging.parts.WordprocessingML.FooterPart;
+import org.docx4j.openpackaging.parts.WordprocessingML.FootnotesPart;
 import org.docx4j.openpackaging.parts.WordprocessingML.HeaderPart;
 import org.docx4j.openpackaging.parts.opendope.ComponentsPart;
 import org.docx4j.openpackaging.parts.relationships.Namespaces;
@@ -378,6 +380,10 @@ public class OpenDoPEHandler {
 				partList.add((HeaderPart) rp.getPart(r));
 			} else if (r.getType().equals(Namespaces.FOOTER)) {
 				partList.add((FooterPart) rp.getPart(r));
+			} else if (r.getType().equals(Namespaces.FOOTNOTES)) {
+				partList.add((FootnotesPart) rp.getPart(r));
+			} else if (r.getType().equals(Namespaces.ENDNOTES)) {
+				partList.add((EndnotesPart) rp.getPart(r));
 			}
 		}
 

--- a/src/main/java/org/docx4j/model/datastorage/OpenDoPEIntegrity.java
+++ b/src/main/java/org/docx4j/model/datastorage/OpenDoPEIntegrity.java
@@ -37,7 +37,9 @@ import org.docx4j.jaxb.JaxbValidationEventHandler;
 import org.docx4j.openpackaging.exceptions.Docx4JException;
 import org.docx4j.openpackaging.packages.WordprocessingMLPackage;
 import org.docx4j.openpackaging.parts.JaxbXmlPart;
+import org.docx4j.openpackaging.parts.WordprocessingML.EndnotesPart;
 import org.docx4j.openpackaging.parts.WordprocessingML.FooterPart;
+import org.docx4j.openpackaging.parts.WordprocessingML.FootnotesPart;
 import org.docx4j.openpackaging.parts.WordprocessingML.HeaderPart;
 import org.docx4j.openpackaging.parts.relationships.Namespaces;
 import org.docx4j.openpackaging.parts.relationships.RelationshipsPart;
@@ -124,6 +126,10 @@ public class OpenDoPEIntegrity {
 					process((HeaderPart) rp.getPart(r));
 				} else if (r.getType().equals(Namespaces.FOOTER)) {
 					process((FooterPart) rp.getPart(r));
+				} else if (r.getType().equals(Namespaces.FOOTNOTES)) {
+					process((FootnotesPart) rp.getPart(r));
+				} else if (r.getType().equals(Namespaces.ENDNOTES)) {
+					process((EndnotesPart) rp.getPart(r));
 				}
 			}
 		}

--- a/src/main/java/org/docx4j/model/datastorage/OpenDoPEReverter.java
+++ b/src/main/java/org/docx4j/model/datastorage/OpenDoPEReverter.java
@@ -34,7 +34,9 @@ import org.docx4j.jaxb.Context;
 import org.docx4j.model.sdt.QueryString;
 import org.docx4j.openpackaging.exceptions.Docx4JException;
 import org.docx4j.openpackaging.packages.WordprocessingMLPackage;
+import org.docx4j.openpackaging.parts.WordprocessingML.EndnotesPart;
 import org.docx4j.openpackaging.parts.WordprocessingML.FooterPart;
+import org.docx4j.openpackaging.parts.WordprocessingML.FootnotesPart;
 import org.docx4j.openpackaging.parts.WordprocessingML.HeaderPart;
 import org.docx4j.openpackaging.parts.opendope.XPathsPart;
 import org.docx4j.openpackaging.parts.relationships.Namespaces;
@@ -175,6 +177,10 @@ public class OpenDoPEReverter {
 				findSdtsInTemplatePart((HeaderPart) rp.getPart(r), sdtPrFinder);
 			} else if (r.getType().equals(Namespaces.FOOTER)) {
 				findSdtsInTemplatePart((FooterPart) rp.getPart(r), sdtPrFinder);
+			} else if (r.getType().equals(Namespaces.FOOTNOTES)) {
+				findSdtsInTemplatePart((FootnotesPart) rp.getPart(r), sdtPrFinder);
+			} else if (r.getType().equals(Namespaces.ENDNOTES)) {
+				findSdtsInTemplatePart((EndnotesPart) rp.getPart(r), sdtPrFinder);
 			}
 		}
 	}
@@ -281,6 +287,10 @@ public class OpenDoPEReverter {
 				handleSdtsInInstancePart((HeaderPart) rp.getPart(r));
 			} else if (r.getType().equals(Namespaces.FOOTER)) {
 				handleSdtsInInstancePart((FooterPart) rp.getPart(r));
+			} else if (r.getType().equals(Namespaces.FOOTNOTES)) {
+				handleSdtsInInstancePart((FootnotesPart) rp.getPart(r));
+			} else if (r.getType().equals(Namespaces.ENDNOTES)) {
+				handleSdtsInInstancePart((EndnotesPart) rp.getPart(r));
 			}
 		}
 	}

--- a/src/main/java/org/docx4j/model/datastorage/RemovalHandler.java
+++ b/src/main/java/org/docx4j/model/datastorage/RemovalHandler.java
@@ -38,7 +38,9 @@ import org.docx4j.jaxb.Context;
 import org.docx4j.openpackaging.exceptions.Docx4JException;
 import org.docx4j.openpackaging.packages.WordprocessingMLPackage;
 import org.docx4j.openpackaging.parts.JaxbXmlPart;
+import org.docx4j.openpackaging.parts.WordprocessingML.EndnotesPart;
 import org.docx4j.openpackaging.parts.WordprocessingML.FooterPart;
+import org.docx4j.openpackaging.parts.WordprocessingML.FootnotesPart;
 import org.docx4j.openpackaging.parts.WordprocessingML.HeaderPart;
 import org.docx4j.openpackaging.parts.relationships.Namespaces;
 import org.docx4j.openpackaging.parts.relationships.RelationshipsPart;
@@ -136,6 +138,10 @@ public class RemovalHandler {
                                 removeSDTs((HeaderPart) rp.getPart(r), quantifier, keys);
                         } else if (r.getType().equals(Namespaces.FOOTER)) {
                                 removeSDTs((FooterPart) rp.getPart(r), quantifier, keys);
+                        } else if (r.getType().equals(Namespaces.FOOTNOTES)) {
+                                removeSDTs((FootnotesPart) rp.getPart(r), quantifier, keys);
+                        } else if (r.getType().equals(Namespaces.ENDNOTES)) {
+                                removeSDTs((EndnotesPart) rp.getPart(r), quantifier, keys);
                         }
                 }
         }

--- a/src/main/java/org/docx4j/openpackaging/parts/WordprocessingML/EndnotesPart.java
+++ b/src/main/java/org/docx4j/openpackaging/parts/WordprocessingML/EndnotesPart.java
@@ -21,15 +21,23 @@
 package org.docx4j.openpackaging.parts.WordprocessingML;
 
 
+import java.util.List;
+
+import org.docx4j.jaxb.Context;
 import org.docx4j.openpackaging.exceptions.InvalidFormatException;
 import org.docx4j.openpackaging.parts.JaxbXmlPartXPathAware;
 import org.docx4j.openpackaging.parts.PartName;
 import org.docx4j.openpackaging.parts.relationships.Namespaces;
+import org.docx4j.wml.ArrayListWml;
 import org.docx4j.wml.CTEndnotes;
+import org.docx4j.wml.ContentAccessor;
 
 
-public final class EndnotesPart extends JaxbXmlPartXPathAware<CTEndnotes> {
+public final class EndnotesPart extends JaxbXmlPartXPathAware<CTEndnotes> implements ContentAccessor {
 	
+	private ArrayListWml<Object> content;
+
+
 	/* Unfortunately, this class can't easily implement
 	 * ContentAccessor, because to do that,
 	 * both CTFootnotes and CTEndnotes would need 
@@ -70,18 +78,22 @@ public final class EndnotesPart extends JaxbXmlPartXPathAware<CTEndnotes> {
 		
 	}
 
-//    /**
-//     * Convenience method to getJaxbElement().getEndnote()
-//     * @since 2.8.1
-//     */
-//    public List<Object> getContent() {
-//    	
-//    	if (this.getJaxbElement()==null) {    		
-//    		this.setJaxbElement( Context.getWmlObjectFactory().createCTEndnotes() );
-//    	}
-//    	
-//    	return this.getJaxbElement().getEndnote();
-//    }	
+
+    /**
+     * Convenience method to getJaxbElement().getEndnote()
+     * @since 2.8.1
+     */
+    public List<Object> getContent() {
+    	if (this.getJaxbElement()==null) {    		
+    		this.setJaxbElement( Context.getWmlObjectFactory().createCTEndnotes() );
+    	}
+    	
+    	if (content == null) {
+            content  = new ArrayListWml<Object>(this.getJaxbElement());
+        }
+        return this.content;
+    	
+    }	
 	
 
 }

--- a/src/main/java/org/docx4j/openpackaging/parts/WordprocessingML/FootnotesPart.java
+++ b/src/main/java/org/docx4j/openpackaging/parts/WordprocessingML/FootnotesPart.java
@@ -21,14 +21,19 @@
 package org.docx4j.openpackaging.parts.WordprocessingML;
 
 
+import java.util.List;
+
+import org.docx4j.jaxb.Context;
 import org.docx4j.openpackaging.exceptions.InvalidFormatException;
 import org.docx4j.openpackaging.parts.JaxbXmlPartXPathAware;
 import org.docx4j.openpackaging.parts.PartName;
 import org.docx4j.openpackaging.parts.relationships.Namespaces;
+import org.docx4j.wml.ArrayListWml;
 import org.docx4j.wml.CTFootnotes;
+import org.docx4j.wml.ContentAccessor;
 
 
-public final class FootnotesPart extends JaxbXmlPartXPathAware<CTFootnotes> {
+public final class FootnotesPart extends JaxbXmlPartXPathAware<CTFootnotes> implements ContentAccessor {
 	// implements ContentAccessor {
 	
 	/* Unfortunately, this class can't easily implement
@@ -51,6 +56,8 @@ public final class FootnotesPart extends JaxbXmlPartXPathAware<CTFootnotes> {
 	 */
 	
 	
+	private ArrayListWml<Object> content;
+
 	public FootnotesPart(PartName partName) throws InvalidFormatException {
 		super(partName);
 		init();		
@@ -72,6 +79,22 @@ public final class FootnotesPart extends JaxbXmlPartXPathAware<CTFootnotes> {
 		
 	}
 
+	/**
+     * Convenience method to getJaxbElement().getEndnote()
+     * @since 2.8.1
+     */
+    public List<Object> getContent() {
+    	if (this.getJaxbElement()==null) {    		
+    		this.setJaxbElement( Context.getWmlObjectFactory().createCTFootnotes() );
+    	}
+    	
+    	if (content == null) {
+            content  = new ArrayListWml<Object>(this.getJaxbElement());
+        }
+        return this.content;
+    	
+    }	
+	
 //    /**
 //     * Convenience method to getJaxbElement().getFootnote()
 //     * @since 2.8.1


### PR DESCRIPTION
HI,

I hope this pull request is created properly.

I've added some extension to Docx4J SDT binding- and removal- handlers, to support FootnotesPart and EndnotesPart. This makes it possible to bind values in these parts as well as remove SDT's from these parts, if requested in the bind-flags. WML parts for EndnotesPart and FootnotesPart implements ContentAccessor (again..). Docx4J now uses RemoveHandler to remove SDT's from supported parts (Main, Footer, Header, Footnotes, Endnotes)

I hope you'll incorporate these changes in a futurer build, or make a similar extension. I need this extension, to be able to use SDT's in footnotes and endnotes.

Thanks a lot.

- Jacob
 
