### PR TITLE
Refactored FormattingSwitch...Tests suites

### DIFF
--- a/src/test/java/org/docx4j/model/fields/FormattingSwitchHelperDateTests.java
+++ b/src/test/java/org/docx4j/model/fields/FormattingSwitchHelperDateTests.java
@@ -1,27 +1,30 @@
 package org.docx4j.model.fields;
 
-import static org.junit.Assert.assertTrue;
-
-import javax.xml.transform.TransformerException;
-
 import org.docx4j.Docx4jProperties;
 import org.docx4j.openpackaging.exceptions.Docx4JException;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
-import java.text.SimpleDateFormat;
+import javax.xml.transform.TransformerException;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Locale;
 
+import static org.junit.Assert.assertTrue;
+
+@RunWith(value = Parameterized.class)
 public class FormattingSwitchHelperDateTests {
-	
+
 	static boolean wasDateFormatInferencerUSA = false;
 	static Locale initialLocale;
 
 	@BeforeClass
 	public static void setUpBeforeClass() throws Exception {
 		// Tests assume USA date format
-		wasDateFormatInferencerUSA = Docx4jProperties.getProperty("docx4j.Fields.Dates.DateFormatInferencer.USA", false);		
+		wasDateFormatInferencerUSA = Docx4jProperties.getProperty("docx4j.Fields.Dates.DateFormatInferencer.USA", false);
 		Docx4jProperties.setProperty("docx4j.Fields.Dates.DateFormatInferencer.USA", true);
 		initialLocale=Locale.getDefault();
 		Locale.setDefault(Locale.ENGLISH); // otherwise dates will be formatted using local language standard
@@ -32,265 +35,91 @@ public class FormattingSwitchHelperDateTests {
 		Docx4jProperties.setProperty("docx4j.Fields.Dates.DateFormatInferencer.USA", wasDateFormatInferencerUSA);
 		Locale.setDefault(initialLocale);
 	}
-	
-	@Test
-	public void testDate1() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\@  ", "4/15/2013");
-	   doit("MERGEFIELD", data, "Error! Switch argument not specified.");
-	   doit("DOCPROPERTY", data, "Error! Switch argument not specified.");
-	} 
-	 
-	@Test
-	public void testDate2() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\@ M/d/yyyy", "4/15/2013");
-	   doit("MERGEFIELD", data, "4/15/2013");
-	   doit("DOCPROPERTY", data, "4/15/2013");
-	} 
-	 
-	@Test
-	public void testDate3() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\@ \"dddd, MMMM dd, yyyy\"", "4/15/2013");
-	   doit("MERGEFIELD", data, "Monday, April 15, 2013");
-	   doit("DOCPROPERTY", data, "Monday, April 15, 2013");
-	} 
-	 
-	@Test
-	public void testDate4() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\@ \"MMMM d, yyyy\"", "4/15/2013");
-	   doit("MERGEFIELD", data, "April 15, 2013");
-	   doit("DOCPROPERTY", data, "April 15, 2013");
-	} 
-	 
-	@Test
-	public void testDate5() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\@ M/d/yy", "4/15/2013");
-	   doit("MERGEFIELD", data, "4/15/13");
-	   doit("DOCPROPERTY", data, "4/15/13");
-	} 
-	 
-	@Test
-	public void testDate6() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\@ yyyy-MM-dd", "4/15/2013");
-	   doit("MERGEFIELD", data, "2013-04-15");
-	   doit("DOCPROPERTY", data, "2013-04-15");
-	} 
-	 
-	@Test
-	public void testDate7() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\@ d-MMM-yy", "4/15/2013");
-	   doit("MERGEFIELD", data, "15-Apr-13");
-	   doit("DOCPROPERTY", data, "15-Apr-13");
-	} 
-	 
-	@Test
-	public void testDate8() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\@ M.d.yyyy", "4/15/2013");
-	   doit("MERGEFIELD", data, "4.15.2013");
-	   doit("DOCPROPERTY", data, "4.15.2013");
-	} 
-	 
-	@Test
-	public void testDate9() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\@ \"MMM. d, yy\"", "4/15/2013");
-	   doit("MERGEFIELD", data, "Apr. 15, 13");
-	   doit("DOCPROPERTY", data, "Apr. 15, 13");
-	} 
-	 
-	@Test
-	public void testDate10() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\@ \"d MMMM yyyy\"", "4/15/2013");
-	   doit("MERGEFIELD", data, "15 April 2013");
-	   doit("DOCPROPERTY", data, "15 April 2013");
-	} 
-	 
-	@Test
-	public void testDate11() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\@ \"MMMM yy\"", "4/15/2013");
-	   doit("MERGEFIELD", data, "April 13");
-	   doit("DOCPROPERTY", data, "April 13");
-	} 
-	 
-	@Test
-	public void testDate12() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\@ MMM-yy", "4/15/2013");
-	   doit("MERGEFIELD", data, "Apr-13");
-	   doit("DOCPROPERTY", data, "Apr-13");
-	} 
 
-	
-	@Test
-	public void testDate13() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\@ \"dddd, MMMM dd, yyyy\"", "4/15/2013");
-	   doit("MERGEFIELD", data, "Monday, April 15, 2013");
-	   doit("DOCPROPERTY", data, "Monday, April 15, 2013");
-	} 
-	
-	
-	@Test
-	public void testDate14() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\@ \"MMMM d, yyyy\"", "4/15/2013");
-	   doit("MERGEFIELD", data, "April 15, 2013");
-	   doit("DOCPROPERTY", data, "April 15, 2013");
-	} 
-	 
-	@Test
-	public void testDate15() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\@ \"MMM. d, yy\"", "4/15/2013");
-	   doit("MERGEFIELD", data, "Apr. 15, 13");
-	   doit("DOCPROPERTY", data, "Apr. 15, 13");
-	} 
-	 
-	@Test
-	public void testDate16() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\@ \"d MMMM yyyy\"", "4/15/2013");
-	   doit("MERGEFIELD", data, "15 April 2013");
-	   doit("DOCPROPERTY", data, "15 April 2013");
-	} 
-	 
-	@Test
-	public void testDate17() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\@ \"MMMM yy\"", "4/15/2013");
-	   doit("MERGEFIELD", data, "April 13");
-	   doit("DOCPROPERTY", data, "April 13");
-	} 
+	@Parameterized.Parameter(value=0)
+	public String format;
 
-	// No quotes ....
-	
+	@Parameterized.Parameter(value=1)
+	public String input;
+
+	@Parameterized.Parameter(value=2)
+	public String result;
+
+	@Parameterized.Parameters(name = "{index}: test {1}({0}) parsed as {2}")
+	public static Collection<Object[]> data() {
+		return Arrays.asList(new Object[][]{
+				{"\\@  ", "4/15/2013","Error! Switch argument not specified."},
+				{"\\@ M/d/yyyy", "4/15/2013","4/15/2013"},
+				{"\\@ \"dddd, MMMM dd, yyyy\"", "4/15/2013","Monday, April 15, 2013"},
+				{"\\@ \"MMMM d, yyyy\"", "4/15/2013","April 15, 2013"},
+				{"\\@ M/d/yy", "4/15/2013","4/15/13"},
+				{"\\@ yyyy-MM-dd", "4/15/2013","2013-04-15"},
+				{"\\@ d-MMM-yy", "4/15/2013","15-Apr-13"},
+				{"\\@ M.d.yyyy", "4/15/2013","4.15.2013"},
+				{"\\@ \"MMM. d, yy\"", "4/15/2013","Apr. 15, 13"},
+				{"\\@ \"d MMMM yyyy\"", "4/15/2013","15 April 2013"},
+				{"\\@ \"MMMM yy\"", "4/15/2013","April 13"},
+				{"\\@ MMM-yy", "4/15/2013","Apr-13"},
+				{"\\@ \"dddd, MMMM dd, yyyy\"", "4/15/2013","Monday, April 15, 2013"},
+				{"\\@ \"MMMM d, yyyy\"", "4/15/2013","April 15, 2013"},
+				{"\\@ \"MMM. d, yy\"", "4/15/2013","Apr. 15, 13"},
+				{"\\@ \"d MMMM yyyy\"", "4/15/2013","15 April 2013"},
+				{"\\@ \"MMMM yy\"", "4/15/2013","April 13"},
+				{"\\@ dddd, MMMM dd, yyyy", "4/15/2013","Monday,"},
+				{"\\@ MMMM d, yyyy", "4/15/2013","April"},
+				{"\\@ MMM. d, yy", "4/15/2013","Apr."},
+				{"\\@ d MMMM yyyy", "4/15/2013","15"},
+				{"\\@ MMMM yy", "4/15/2013","April"}		});
+	}
+
 	@Test
-	public void testDateNoQuotes13() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\@ dddd, MMMM dd, yyyy", "4/15/2013");
-	   doit("MERGEFIELD", data, "Monday,");
-	   doit("DOCPROPERTY", data, "Monday,");
-	} 
-	
-	
-	@Test
-	public void testDateNoQuotes14() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\@ MMMM d, yyyy", "4/15/2013");
-	   doit("MERGEFIELD", data, "April");
-	   doit("DOCPROPERTY", data, "April");
-	} 
-	 
-	@Test
-	public void testDateNoQuotes15() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\@ MMM. d, yy", "4/15/2013");
-	   doit("MERGEFIELD", data, "Apr.");
-	   doit("DOCPROPERTY", data, "Apr.");
-	} 
-	 
-	@Test
-	public void testDateNoQuotes16() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\@ d MMMM yyyy", "4/15/2013");
-	   doit("MERGEFIELD", data, "15");
-	   doit("DOCPROPERTY", data, "15");
-	} 
-	 
-	@Test
-	public void testDateNoQuotes17() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\@ MMMM yy", "4/15/2013");
-	   doit("MERGEFIELD", data, "April");
-	   doit("DOCPROPERTY", data, "April");
-	} 
-	 
-	
+	public void testDateParsed()throws TransformerException, Docx4JException {
+		SwitchTestData data = new SwitchTestData(format, input);
+		doit("MERGEFIELD", data, result);
+		doit("DOCPROPERTY", data, result);
+	}
+
+
 	// TODO: where no time is passed in..
 	// for DOCPROPERTY, Word uses 12:00 AM
 	// for DATE and MERGEFIELD, Word uses current time
-	// (for =, Word also used current date) 
-	
-	
-//	@Test
-//	public void testDate18() throws TransformerException, Docx4JException {
-//	   SwitchTestData data = new SwitchTestData("\\@ M/d/yyyy h:mm am/pm", "4/15/2013");
-//	   doit("MERGEFIELD", data, "1/3/2006 5:28 PM");
-//	   doit("DOCPROPERTY", data, "1/3/2006 5:28 PM");
-//	} 
-//	 
-//	@Test
-//	public void testDate19() throws TransformerException, Docx4JException {
-//	   SwitchTestData data = new SwitchTestData("\\@ M/d/yyyy h:mm:ss am/pm", "4/15/2013");
-//	   doit("MERGEFIELD", data, "1/3/2006 5:28:34 PM");
-//	   doit("DOCPROPERTY", data, "1/3/2006 5:28:34 PM");
-//	} 
-//	 
-//	@Test
-//	public void testDate20() throws TransformerException, Docx4JException {
-//	   SwitchTestData data = new SwitchTestData("\\@ \"M/d/yyyy h:mm am/pm\"", "4/15/2013");
-//	   doit("MERGEFIELD", data, "4/15/2013 5:28 PM");
-//	   doit("DOCPROPERTY", data, "4/15/2013 5:28 PM");
-//	} 
-//	 
-//	@Test
-//	public void testDate21() throws TransformerException, Docx4JException {
-//	   SwitchTestData data = new SwitchTestData("\\@ \"M/d/yyyy h:mm:ss am/pm\"", "4/15/2013");
-//	   doit("MERGEFIELD", data, "4/15/2013 5:28:34 PM");
-//	   doit("DOCPROPERTY", data, "4/15/2013 5:28:34 PM");
-//	} 
-//	 
-//	@Test
-//	public void testDate22() throws TransformerException, Docx4JException {
-//	   SwitchTestData data = new SwitchTestData("\\@ h:mm am/pm", "4/15/2013");
-//	   doit("MERGEFIELD", data, "5:28 PM");
-//	   doit("DOCPROPERTY", data, "5:28 PM");
-//	} 
-//	 
-//	@Test
-//	public void testDate23() throws TransformerException, Docx4JException {
-//	   SwitchTestData data = new SwitchTestData("\\@ h:mm:ss am/pm", "4/15/2013");
-//	   doit("MERGEFIELD", data, "5:28:34 PM");
-//	   doit("DOCPROPERTY", data, "5:28:34 PM");
-//	} 
-//	 
-//	@Test
-//	public void testDate24() throws TransformerException, Docx4JException {
-//	   SwitchTestData data = new SwitchTestData("\\@ \"h:mm am/pm\"", "4/15/2013");
-//	   doit("MERGEFIELD", data, "5:28 PM");
-//	   doit("DOCPROPERTY", data, "5:28 PM");
-//	} 
-//	 
-//	@Test
-//	public void testDate25() throws TransformerException, Docx4JException {
-//	   SwitchTestData data = new SwitchTestData("\\@ \"h:mm:ss am/pm\"", "4/15/2013");
-//	   doit("MERGEFIELD", data, "5:28:34 PM");
-//	   doit("DOCPROPERTY", data, "5:28:34 PM");
-//	} 
-//	 
-//	@Test
-//	public void testDate26() throws TransformerException, Docx4JException {
-//	   SwitchTestData data = new SwitchTestData("\\@ HH:mm", "4/15/2013");
-//	   doit("MERGEFIELD", data, "17:28");
-//	   doit("DOCPROPERTY", data, "17:28");
-//	} 
-//	 
-//	@Test
-//	public void testDate27() throws TransformerException, Docx4JException {
-//	   SwitchTestData data = new SwitchTestData("\\@ \"'Today is 'HH:mm:ss\"", "4/15/2013");
-//	   doit("MERGEFIELD", data, "Today is 17:28:34");
-//	   doit("DOCPROPERTY", data, "Today is 17:28:34");
-//	} 
-	
+	// (for =, Word also used current date)
+
+	// tests for time were commented out. To enable it, add to parameters values:
+	//{"\\@ M/d/yyyy h:mm am/pm", "4/15/2013","1/3/2006 5:28 PM"},
+	//{"\\@ M/d/yyyy h:mm:ss am/pm", "4/15/2013","1/3/2006 5:28:34 PM"},
+	//{"\\@ \"M/d/yyyy h:mm am/pm\"", "4/15/2013","4/15/2013 5:28 PM"},
+	//{"\\@ \"M/d/yyyy h:mm:ss am/pm\"", "4/15/2013","4/15/2013 5:28:34 PM"},
+	//{"\\@ h:mm am/pm", "4/15/2013","5:28 PM"},
+	//{"\\@ h:mm:ss am/pm", "4/15/2013","5:28:34 PM"},
+	//{"\\@ \"h:mm am/pm\"", "4/15/2013","5:28 PM"},
+	//{"\\@ \"h:mm:ss am/pm\"", "4/15/2013","5:28:34 PM"},
+	//{"\\@ HH:mm", "4/15/2013","17:28"},
+	//{"\\@ \"'Today is 'HH:mm:ss\"", "4/15/2013","Today is 17:28:34"}
+
+
 	// ---------------------------------------------------------------------------------------
-	
+
 	private void doit(String fieldname, SwitchTestData triple, String expectedResult)  throws TransformerException, Docx4JException {
-		
+
 		String instr = fieldname + " foo " + triple.format;
 		String result = getFormat(instr, triple.val);
 		System.out.println(result);
 		assertTrue(result.equals(expectedResult));
 	}
-	
+
 	private String getFormat(String instr, String val) throws TransformerException, Docx4JException {
-			
+
 		FldSimpleModel fsm = new FldSimpleModel();
 		fsm.build(instr);
-		return FormattingSwitchHelper.applyFormattingSwitch(null, fsm, val);		
+		return FormattingSwitchHelper.applyFormattingSwitch(null, fsm, val);
 	}
-		
+
 	private static class SwitchTestData {
 
 		String format;
 		String val;
-		
+
 		public String toString() {
 			return "format " + format + " to data " + val;
 		}
@@ -301,6 +130,6 @@ public class FormattingSwitchHelperDateTests {
 			this.val = val;
 		}
 	}
-	
-	
+
+
 }

--- a/src/test/java/org/docx4j/model/fields/FormattingSwitchHelperDateTests.java
+++ b/src/test/java/org/docx4j/model/fields/FormattingSwitchHelperDateTests.java
@@ -10,20 +10,27 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.text.SimpleDateFormat;
+import java.util.Locale;
+
 public class FormattingSwitchHelperDateTests {
 	
 	static boolean wasDateFormatInferencerUSA = false;
-	
+	static Locale initialLocale;
+
 	@BeforeClass
 	public static void setUpBeforeClass() throws Exception {
 		// Tests assume USA date format
 		wasDateFormatInferencerUSA = Docx4jProperties.getProperty("docx4j.Fields.Dates.DateFormatInferencer.USA", false);		
 		Docx4jProperties.setProperty("docx4j.Fields.Dates.DateFormatInferencer.USA", true);
+		initialLocale=Locale.getDefault();
+		Locale.setDefault(Locale.ENGLISH); // otherwise dates will be formatted using local language standard
 	}
 
 	@AfterClass
 	public static void tearDownAfterClass() throws Exception {
 		Docx4jProperties.setProperty("docx4j.Fields.Dates.DateFormatInferencer.USA", wasDateFormatInferencerUSA);
+		Locale.setDefault(initialLocale);
 	}
 	
 	@Test

--- a/src/test/java/org/docx4j/model/fields/FormattingSwitchHelperDateTests.java
+++ b/src/test/java/org/docx4j/model/fields/FormattingSwitchHelperDateTests.java
@@ -16,7 +16,7 @@ import java.util.Locale;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(value = Parameterized.class)
-public class FormattingSwitchHelperDateTests {
+public class FormattingSwitchHelperDateTests extends FormattingTestsBase {
 
 	static boolean wasDateFormatInferencerUSA = false;
 	static Locale initialLocale;
@@ -96,40 +96,5 @@ public class FormattingSwitchHelperDateTests {
 	//{"\\@ \"h:mm:ss am/pm\"", "4/15/2013","5:28:34 PM"},
 	//{"\\@ HH:mm", "4/15/2013","17:28"},
 	//{"\\@ \"'Today is 'HH:mm:ss\"", "4/15/2013","Today is 17:28:34"}
-
-
-	// ---------------------------------------------------------------------------------------
-
-	private void doit(String fieldname, SwitchTestData triple, String expectedResult)  throws TransformerException, Docx4JException {
-
-		String instr = fieldname + " foo " + triple.format;
-		String result = getFormat(instr, triple.val);
-		System.out.println(result);
-		assertTrue(result.equals(expectedResult));
-	}
-
-	private String getFormat(String instr, String val) throws TransformerException, Docx4JException {
-
-		FldSimpleModel fsm = new FldSimpleModel();
-		fsm.build(instr);
-		return FormattingSwitchHelper.applyFormattingSwitch(null, fsm, val);
-	}
-
-	private static class SwitchTestData {
-
-		String format;
-		String val;
-
-		public String toString() {
-			return "format " + format + " to data " + val;
-		}
-
-		public SwitchTestData(String format, String val) {
-
-			this.format = format;
-			this.val = val;
-		}
-	}
-
 
 }

--- a/src/test/java/org/docx4j/model/fields/FormattingSwitchHelperGeneralTests.java
+++ b/src/test/java/org/docx4j/model/fields/FormattingSwitchHelperGeneralTests.java
@@ -6,234 +6,91 @@ import javax.xml.transform.TransformerException;
 
 import org.docx4j.openpackaging.exceptions.Docx4JException;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+import java.util.Arrays;
+import java.util.Collection;
+
+@RunWith(value = Parameterized.class)
 public class FormattingSwitchHelperGeneralTests {
-	
 
-	@Test
-	public void testStringNotSpecified() throws TransformerException, Docx4JException {
-		// For DOCPROPERTY and MERGEFIELD, = (and presumably all others), \* without arg in Word 2010 sp1
-		// results in Error! Switch argument not specified, .
-		SwitchTestData triple = new SwitchTestData("\\* ", "mary smith", "Error! Switch argument not specified.");
-		doit("MERGEFIELD", triple); doit("DOCPROPERTY", triple);
+	// For DOCPROPERTY and MERGEFIELD, = (and presumably all others), \* without arg in Word 2010 sp1
+	// results in Error! Switch argument not specified, .
+
+	@Parameterized.Parameter(value=0)
+	public String format;
+
+	@Parameterized.Parameter(value=1)
+	public String input;
+
+	@Parameterized.Parameter(value=2)
+	public String result;
+
+	@Parameterized.Parameters(name = "{index}: test {1}({0}) parsed as {2}")
+	public static Collection<Object[]> data() {
+		return Arrays.asList(new Object[][]{
+				{"\\* ", "mary smith", "Error! Switch argument not specified."},
+				{"\\* Caps", "mary smith", "Mary Smith"},
+				{"\\* Upper", "mary smith", "MARY SMITH"},
+				{"\\* MERGEFORMAT", "Mary SmiTH", "Mary SmiTH"},
+				// it was commented out
+				//{"\\* madeupswitch", "\"mary smith\"", "Error! Unknown switch argument"},
+				//{"\\* madeupswitch", "mary smith", "Error! Unknown switch argument"},
+				{"\\* MERGEFORMAT", "01", "01"},
+				{"\\* MERGEFORMAT", "0.1", "0.1"},
+				{"\\* MERGEFORMAT", "0.0", "0.0"},
+				{"\\* MERGEFORMAT", "0.00", "0.00"},
+				{"\\* MERGEFORMAT", "0.", "0."},
+				{"\\* MERGEFORMAT", "0.1 A", "0.1 A"},
+				{"\\* MERGEFORMAT", "0.1 1", "0.1 1"},
+				{"\\* MERGEFORMAT", "0.1 .", "0.1 ."},
+				{"\\* MERGEFORMAT", "0.00 0", "0.00 0"},
+				{"\\* MERGEFORMAT", "0.00 1", "0.00 1"},
+				{"\\* MERGEFORMAT", "0.00 A", "0.00 A"},
+				{"\\* MERGEFORMAT", "0000123456", "0000123456"},
+				{"\\* MERGEFORMAT", "000012345.006", "000012345.006"},
+				{"\\* MERGEFORMAT", "0000123AA456", "0000123AA456"},
+				{"\\* MERGEFORMAT", "0000123AA45.006", "0000123AA45.006"},
+				{"\\* Caps", "\"mary smith\"", "\"Mary Smith\""},
+				{"\\* Caps", "\"marysmith\"", "\"Marysmith\""},
+				{"\\* FirstCap", "\"mary smith\"", "\"Mary smith\""},
+				{"\\* Lower", "\"Mary Smith\"", "\"mary smith\""},
+				{"\\* Upper", "\"Mary Smith\"", "\"MARY SMITH\""},
+				{"\\* MERGEFORMAT", "\"Mary SmiTH\"", "\"Mary SmiTH\""},
+				{"\\* MERGEFORMAT", "\"mary SmiTH\"", "\"mary SmiTH\""},
+				{"\\* MERGEFORMAT", "\"0.1 A\"", "\"0.1 A\""},
+				{"\\* MERGEFORMAT", "\"0.1 1\"", "\"0.1 1\""},
+				{"\\* MERGEFORMAT", "\"0.1 .\"", "\"0.1 .\""},
+				{"\\* MERGEFORMAT", "\"0.00 0\"", "\"0.00 0\""},
+				{"\\* MERGEFORMAT", "\"0.00 1\"", "\"0.00 1\""},
+				{"\\* MERGEFORMAT", "\"0.00 A\"", "\"0.00 A\""}		});
 	}
 
 	@Test
-	public void testStringCaps() throws TransformerException, Docx4JException {
-		   SwitchTestData triple = new SwitchTestData("\\* Caps", "mary smith", "Mary Smith");
-		doit("MERGEFIELD", triple); doit("DOCPROPERTY", triple);
+	public void testDateParsed()throws TransformerException, Docx4JException {
+		SwitchTestData triple = new SwitchTestData(format, input, result);
+		doit("MERGEFIELD", triple);
+		doit("DOCPROPERTY", triple);
 	}
 
-	@Test
-	public void testStringUpper() throws TransformerException, Docx4JException {
-		   SwitchTestData triple = new SwitchTestData("\\* Upper", "mary smith", "MARY SMITH");
-		doit("MERGEFIELD", triple); doit("DOCPROPERTY", triple);
-	}
-
-	@Test
-	public void testStringNone1() throws TransformerException, Docx4JException {
-		   SwitchTestData triple = new SwitchTestData("\\* MERGEFORMAT", "Mary SmiTH", "Mary SmiTH");
-		doit("MERGEFIELD", triple); doit("DOCPROPERTY", triple);
-	}
-
-//	@Test
-//	public void testStringmadeupswitch1() throws TransformerException, Docx4JException {
-//		   SwitchTestData triple = new SwitchTestData("\\* madeupswitch", "\"mary smith\"", "Error! Unknown switch argument");
-//		doit("MERGEFIELD", triple); doit("DOCPROPERTY", triple);
-//	}
-//
-//	@Test
-//	public void testStringmadeupswitch2() throws TransformerException, Docx4JException {
-//		   SwitchTestData triple = new SwitchTestData("\\* madeupswitch", "mary smith", "Error! Unknown switch argument");
-//		doit("MERGEFIELD", triple); doit("DOCPROPERTY", triple);
-//	}
-
-	@Test
-	public void testStringNone2() throws TransformerException, Docx4JException {
-		   SwitchTestData triple = new SwitchTestData("\\* MERGEFORMAT", "01", "01");
-		doit("MERGEFIELD", triple); doit("DOCPROPERTY", triple);
-	}
-
-	@Test
-	public void testStringNone3() throws TransformerException, Docx4JException {
-		   SwitchTestData triple = new SwitchTestData("\\* MERGEFORMAT", "0.1", "0.1");
-		doit("MERGEFIELD", triple); doit("DOCPROPERTY", triple);
-	}
-
-	@Test
-	public void testStringNone4() throws TransformerException, Docx4JException {
-		   SwitchTestData triple = new SwitchTestData("\\* MERGEFORMAT", "0.0", "0.0");
-		doit("MERGEFIELD", triple); doit("DOCPROPERTY", triple);
-	}
-
-	@Test
-	public void testStringNone5() throws TransformerException, Docx4JException {
-		   SwitchTestData triple = new SwitchTestData("\\* MERGEFORMAT", "0.00", "0.00");
-		doit("MERGEFIELD", triple); doit("DOCPROPERTY", triple);
-	}
-
-	@Test
-	public void testStringNone6() throws TransformerException, Docx4JException {
-		   SwitchTestData triple = new SwitchTestData("\\* MERGEFORMAT", "0.", "0.");
-		doit("MERGEFIELD", triple); doit("DOCPROPERTY", triple);
-	}
-
-	@Test
-	public void testStringNone7() throws TransformerException, Docx4JException {
-		   SwitchTestData triple = new SwitchTestData("\\* MERGEFORMAT", "0.1 A", "0.1 A");
-		doit("MERGEFIELD", triple); doit("DOCPROPERTY", triple);
-	}
-
-	@Test
-	public void testStringNone8() throws TransformerException, Docx4JException {
-		   SwitchTestData triple = new SwitchTestData("\\* MERGEFORMAT", "0.1 1", "0.1 1");
-		doit("MERGEFIELD", triple); doit("DOCPROPERTY", triple);
-	}
-
-	@Test
-	public void testStringNone9() throws TransformerException, Docx4JException {
-		   SwitchTestData triple = new SwitchTestData("\\* MERGEFORMAT", "0.1 .", "0.1 .");
-		doit("MERGEFIELD", triple); doit("DOCPROPERTY", triple);
-	}
-
-	@Test
-	public void testStringNone10() throws TransformerException, Docx4JException {
-		   SwitchTestData triple = new SwitchTestData("\\* MERGEFORMAT", "0.00 0", "0.00 0");
-		doit("MERGEFIELD", triple); doit("DOCPROPERTY", triple);
-	}
-
-	@Test
-	public void testStringNone11() throws TransformerException, Docx4JException {
-		   SwitchTestData triple = new SwitchTestData("\\* MERGEFORMAT", "0.00 1", "0.00 1");
-		doit("MERGEFIELD", triple); doit("DOCPROPERTY", triple);
-	}
-
-	@Test
-	public void testStringNone12() throws TransformerException, Docx4JException {
-		   SwitchTestData triple = new SwitchTestData("\\* MERGEFORMAT", "0.00 A", "0.00 A");
-		doit("MERGEFIELD", triple); doit("DOCPROPERTY", triple);
-	}
-
-	@Test
-	public void testStringNone13() throws TransformerException, Docx4JException {
-		   SwitchTestData triple = new SwitchTestData("\\* MERGEFORMAT", "0000123456", "0000123456");
-		doit("MERGEFIELD", triple); doit("DOCPROPERTY", triple);
-	}
-
-	@Test
-	public void testStringNone14() throws TransformerException, Docx4JException {
-		   SwitchTestData triple = new SwitchTestData("\\* MERGEFORMAT", "000012345.006", "000012345.006");
-		doit("MERGEFIELD", triple); doit("DOCPROPERTY", triple);
-	}
-
-	@Test
-	public void testStringNone15() throws TransformerException, Docx4JException {
-		   SwitchTestData triple = new SwitchTestData("\\* MERGEFORMAT", "0000123AA456", "0000123AA456");
-		doit("MERGEFIELD", triple); doit("DOCPROPERTY", triple);
-	}
-
-	@Test
-	public void testStringNone16() throws TransformerException, Docx4JException {
-		   SwitchTestData triple = new SwitchTestData("\\* MERGEFORMAT", "0000123AA45.006", "0000123AA45.006");
-		doit("MERGEFIELD", triple); doit("DOCPROPERTY", triple);
-	}
-
-	@Test
-	public void testStringCapsQuote() throws TransformerException, Docx4JException {
-		   SwitchTestData triple = new SwitchTestData("\\* Caps", "\"mary smith\"", "\"Mary Smith\"");
-		doit("MERGEFIELD", triple); doit("DOCPROPERTY", triple);
-	}
-
-	@Test
-	public void testStringCaps2Quote() throws TransformerException, Docx4JException {
-		   SwitchTestData triple = new SwitchTestData("\\* Caps", "\"marysmith\"", "\"Marysmith\"");
-		doit("MERGEFIELD", triple); doit("DOCPROPERTY", triple);
-	}
-
-	@Test
-	public void testStringFirstCapQuote() throws TransformerException, Docx4JException {
-		   SwitchTestData triple = new SwitchTestData("\\* FirstCap", "\"mary smith\"", "\"Mary smith\"");
-		doit("MERGEFIELD", triple); doit("DOCPROPERTY", triple);
-	}
-
-	@Test
-	public void testStringLowerQuote() throws TransformerException, Docx4JException {
-		   SwitchTestData triple = new SwitchTestData("\\* Lower", "\"Mary Smith\"", "\"mary smith\"");
-		doit("MERGEFIELD", triple); doit("DOCPROPERTY", triple);
-	}
-
-	@Test
-	public void testStringUpperQuote() throws TransformerException, Docx4JException {
-		   SwitchTestData triple = new SwitchTestData("\\* Upper", "\"Mary Smith\"", "\"MARY SMITH\"");
-		doit("MERGEFIELD", triple); doit("DOCPROPERTY", triple);
-	}
-
-	@Test
-	public void testStringNone1Quote() throws TransformerException, Docx4JException {
-		   SwitchTestData triple = new SwitchTestData("\\* MERGEFORMAT", "\"Mary SmiTH\"", "\"Mary SmiTH\"");
-		doit("MERGEFIELD", triple); doit("DOCPROPERTY", triple);
-	}
-
-	@Test
-	public void testStringNone2Quote() throws TransformerException, Docx4JException {
-		   SwitchTestData triple = new SwitchTestData("\\* MERGEFORMAT", "\"mary SmiTH\"", "\"mary SmiTH\"");
-		doit("MERGEFIELD", triple); doit("DOCPROPERTY", triple);
-	}
-
-	@Test
-	public void testStringNone3Quote() throws TransformerException, Docx4JException {
-		   SwitchTestData triple = new SwitchTestData("\\* MERGEFORMAT", "\"0.1 A\"", "\"0.1 A\"");
-		doit("MERGEFIELD", triple); doit("DOCPROPERTY", triple);
-	}
-
-	@Test
-	public void testStringNone4Quote() throws TransformerException, Docx4JException {
-		   SwitchTestData triple = new SwitchTestData("\\* MERGEFORMAT", "\"0.1 1\"", "\"0.1 1\"");
-		doit("MERGEFIELD", triple); doit("DOCPROPERTY", triple);
-	}
-
-	@Test
-	public void testStringNone5Quote() throws TransformerException, Docx4JException {
-		   SwitchTestData triple = new SwitchTestData("\\* MERGEFORMAT", "\"0.1 .\"", "\"0.1 .\"");
-		doit("MERGEFIELD", triple); doit("DOCPROPERTY", triple);
-	}
-
-	@Test
-	public void testStringNone6Quote() throws TransformerException, Docx4JException {
-		   SwitchTestData triple = new SwitchTestData("\\* MERGEFORMAT", "\"0.00 0\"", "\"0.00 0\"");
-		doit("MERGEFIELD", triple); doit("DOCPROPERTY", triple);
-	}
-
-	@Test
-	public void testStringNone7Quote() throws TransformerException, Docx4JException {
-		   SwitchTestData triple = new SwitchTestData("\\* MERGEFORMAT", "\"0.00 1\"", "\"0.00 1\"");
-		doit("MERGEFIELD", triple); doit("DOCPROPERTY", triple);
-	}
-
-	@Test
-	public void testStringNone8Quote() throws TransformerException, Docx4JException {
-		   SwitchTestData triple = new SwitchTestData("\\* MERGEFORMAT", "\"0.00 A\"", "\"0.00 A\"");
-		doit("MERGEFIELD", triple); doit("DOCPROPERTY", triple);
-	}
-	
-	
 	// ---------------------------------------------------------------------------------------
-	
+
 	private void doit(String fieldname, SwitchTestData triple)  throws TransformerException, Docx4JException {
-		
+
 		String instr = fieldname + " foo " + triple.format;
 		String result = getFormat(instr, triple.val);
 		assertTrue(result.equals(triple.expectedResult));
 	}
-	
+
 	private String getFormat(String instr, String val) throws TransformerException, Docx4JException {
-			
+
 		FldSimpleModel fsm = new FldSimpleModel();
 		fsm.build(instr);
-		return FormattingSwitchHelper.applyFormattingSwitch(null, fsm, val);		
+		return FormattingSwitchHelper.applyFormattingSwitch(null, fsm, val);
 	}
-	
-	
+
+
 	private static class SwitchTestData {
 
 		String format;
@@ -247,6 +104,6 @@ public class FormattingSwitchHelperGeneralTests {
 			this.expectedResult = expectedResult;
 		}
 	}
-	
-	
+
+
 }

--- a/src/test/java/org/docx4j/model/fields/FormattingSwitchHelperGeneralTests.java
+++ b/src/test/java/org/docx4j/model/fields/FormattingSwitchHelperGeneralTests.java
@@ -13,7 +13,7 @@ import java.util.Arrays;
 import java.util.Collection;
 
 @RunWith(value = Parameterized.class)
-public class FormattingSwitchHelperGeneralTests {
+public class FormattingSwitchHelperGeneralTests extends FormattingTestsBase{
 
 	// For DOCPROPERTY and MERGEFIELD, = (and presumably all others), \* without arg in Word 2010 sp1
 	// results in Error! Switch argument not specified, .
@@ -69,41 +69,8 @@ public class FormattingSwitchHelperGeneralTests {
 
 	@Test
 	public void testDateParsed()throws TransformerException, Docx4JException {
-		SwitchTestData triple = new SwitchTestData(format, input, result);
-		doit("MERGEFIELD", triple);
-		doit("DOCPROPERTY", triple);
+		SwitchTestData triple = new SwitchTestData(format, input);
+		doit("MERGEFIELD", triple, result);
+		doit("DOCPROPERTY", triple, result);
 	}
-
-	// ---------------------------------------------------------------------------------------
-
-	private void doit(String fieldname, SwitchTestData triple)  throws TransformerException, Docx4JException {
-
-		String instr = fieldname + " foo " + triple.format;
-		String result = getFormat(instr, triple.val);
-		assertTrue(result.equals(triple.expectedResult));
-	}
-
-	private String getFormat(String instr, String val) throws TransformerException, Docx4JException {
-
-		FldSimpleModel fsm = new FldSimpleModel();
-		fsm.build(instr);
-		return FormattingSwitchHelper.applyFormattingSwitch(null, fsm, val);
-	}
-
-
-	private static class SwitchTestData {
-
-		String format;
-		String val;
-		String expectedResult;
-
-		public SwitchTestData(String format, String val, String expectedResult) {
-
-			this.format = format;
-			this.val = val;
-			this.expectedResult = expectedResult;
-		}
-	}
-
-
 }

--- a/src/test/java/org/docx4j/model/fields/FormattingSwitchHelperInvalidNumericTests.java
+++ b/src/test/java/org/docx4j/model/fields/FormattingSwitchHelperInvalidNumericTests.java
@@ -1,0 +1,109 @@
+package org.docx4j.model.fields;
+
+import org.docx4j.openpackaging.exceptions.Docx4JException;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import javax.xml.transform.TransformerException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Locale;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+@RunWith(value = Parameterized.class)
+public class FormattingSwitchHelperInvalidNumericTests {
+
+	static Locale initialLocale;
+
+	@BeforeClass
+	public static void setUpBeforeClass() throws Exception {
+		initialLocale=Locale.getDefault();
+		Locale.setDefault(Locale.ENGLISH); // decimal delimiter is different in another locale
+	}
+
+	@AfterClass
+	public static void tearDownAfterClass() throws Exception {
+		Locale.setDefault(initialLocale);
+	}
+
+	@Parameterized.Parameter(value=0)
+	public String format;
+
+	@Parameterized.Parameter(value=1)
+	public String input;
+
+	@Parameterized.Parameters(name = "{index}: test {1}({0}) is invalid")
+	public static Collection<Object[]> data() {
+		return Arrays.asList(new Object[][]{
+		{"\\# x#.#x", "123456"},
+				{"\\# x#.#x", "123.456"},
+				{"\\# .###x", "-0.75"},
+				{"\\# .###x", "-.75"},
+				{"\\# .###", "-0.75"},
+				{"\\# .###", "-.75"},
+				{"\\# .000", "-0.75"},
+				{"\\# .000", "-.75"},
+				{"\\# .00", "95.4"},
+				{"\\# .##", "95.4"},
+				{"\\# #%#", "33"},
+				{"\\# #$#", "33"},
+				{"\\# #'y'#", "34"}});
+	}
+	// COMPLEX !
+
+	@Test
+	public void testInvalidNumberDetected() throws TransformerException, Docx4JException {
+		SwitchTestData data = new SwitchTestData(format, input);
+		try {
+			doit("MERGEFIELD", data, "class org.docx4j.model.fields.FieldFormattingException");
+		} catch (Exception e) {
+			System.out.println("[" + data.toString() + "] " + e.getMessage());
+			assertTrue(FieldFormattingException.class.isAssignableFrom(e.getClass()));
+		}
+		try {
+			doit("DOCPROPERTY", data, "class org.docx4j.model.fields.FieldFormattingException");
+		} catch (Exception e) {
+			System.out.println("[" + data.toString() + "] " + e.getMessage());
+			assertTrue(FieldFormattingException.class.isAssignableFrom(e.getClass()));
+		}
+	}
+
+	// ---------------------------------------------------------------------------------------
+
+	private void doit(String fieldname, SwitchTestData triple, String expectedResult)  throws TransformerException, Docx4JException {
+
+		String instr = fieldname + " foo " + triple.format;
+		String result = getFormat(instr, triple.val);
+		assertTrue(result.equals(expectedResult));
+	}
+
+	private String getFormat(String instr, String val) throws TransformerException, Docx4JException {
+
+		FldSimpleModel fsm = new FldSimpleModel();
+		fsm.build(instr);
+		return FormattingSwitchHelper.applyFormattingSwitch(null, fsm, val);
+	}
+
+	private static class SwitchTestData {
+
+		String format;
+		String val;
+
+		public String toString() {
+			return "format " + format + " to data " + val;
+		}
+
+		public SwitchTestData(String format, String val) {
+
+			this.format = format;
+			this.val = val;
+		}
+	}
+
+
+}

--- a/src/test/java/org/docx4j/model/fields/FormattingSwitchHelperInvalidNumericTests.java
+++ b/src/test/java/org/docx4j/model/fields/FormattingSwitchHelperInvalidNumericTests.java
@@ -16,7 +16,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 @RunWith(value = Parameterized.class)
-public class FormattingSwitchHelperInvalidNumericTests {
+public class FormattingSwitchHelperInvalidNumericTests extends FormattingTestsBase{
 
 	static Locale initialLocale;
 
@@ -70,38 +70,6 @@ public class FormattingSwitchHelperInvalidNumericTests {
 		} catch (Exception e) {
 			System.out.println("[" + data.toString() + "] " + e.getMessage());
 			assertTrue(FieldFormattingException.class.isAssignableFrom(e.getClass()));
-		}
-	}
-
-	// ---------------------------------------------------------------------------------------
-
-	private void doit(String fieldname, SwitchTestData triple, String expectedResult)  throws TransformerException, Docx4JException {
-
-		String instr = fieldname + " foo " + triple.format;
-		String result = getFormat(instr, triple.val);
-		assertTrue(result.equals(expectedResult));
-	}
-
-	private String getFormat(String instr, String val) throws TransformerException, Docx4JException {
-
-		FldSimpleModel fsm = new FldSimpleModel();
-		fsm.build(instr);
-		return FormattingSwitchHelper.applyFormattingSwitch(null, fsm, val);
-	}
-
-	private static class SwitchTestData {
-
-		String format;
-		String val;
-
-		public String toString() {
-			return "format " + format + " to data " + val;
-		}
-
-		public SwitchTestData(String format, String val) {
-
-			this.format = format;
-			this.val = val;
 		}
 	}
 

--- a/src/test/java/org/docx4j/model/fields/FormattingSwitchHelperNoSwitchTests.java
+++ b/src/test/java/org/docx4j/model/fields/FormattingSwitchHelperNoSwitchTests.java
@@ -6,462 +6,116 @@ import javax.xml.transform.TransformerException;
 
 import org.docx4j.openpackaging.exceptions.Docx4JException;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+import java.util.Arrays;
+import java.util.Collection;
+
+@RunWith(value = Parameterized.class)
 public class FormattingSwitchHelperNoSwitchTests {
-	
-	// In all cases, output = input 
-	
-	@Test
-	public void testNone1() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "mary smith");
-	   doit("MERGEFIELD", data, "mary smith");
-	   doit("DOCPROPERTY", data, "mary smith");
-	} 
-	 
-	@Test
-	public void testNone2() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "mary\"smith");
-	   doit("MERGEFIELD", data, "mary\"smith");
-	   doit("DOCPROPERTY", data, "mary\"smith");
-	} 
-	 
-	@Test
-	public void testNone3() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "\"mary smith\"");
-	   doit("MERGEFIELD", data, "\"mary smith\"");
-	   doit("DOCPROPERTY", data, "\"mary smith\"");
-	} 
-	 
-	@Test
-	public void testNone4() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "\"marysmith\"");
-	   doit("MERGEFIELD", data, "\"marysmith\"");
-	   doit("DOCPROPERTY", data, "\"marysmith\"");
-	} 
-	 
-	@Test
-	public void testNone5() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "\"mary smith\"");
-	   doit("MERGEFIELD", data, "\"mary smith\"");
-	   doit("DOCPROPERTY", data, "\"mary smith\"");
-	} 
-	 
-	@Test
-	public void testNone6() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "\"Mary Smith\"");
-	   doit("MERGEFIELD", data, "\"Mary Smith\"");
-	   doit("DOCPROPERTY", data, "\"Mary Smith\"");
-	} 
-	 
-	@Test
-	public void testNone7() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "\"Mary Smith\"");
-	   doit("MERGEFIELD", data, "\"Mary Smith\"");
-	   doit("DOCPROPERTY", data, "\"Mary Smith\"");
-	} 
-	 
-	@Test
-	public void testNone8() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "\"Mary Smith\" Capoop");
-	   doit("MERGEFIELD", data, "\"Mary Smith\" Capoop");
-	   doit("DOCPROPERTY", data, "\"Mary Smith\" Capoop");
-	} 
-	 
-	@Test
-	public void testNone9() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "\"Mary SmiTH\"");
-	   doit("MERGEFIELD", data, "\"Mary SmiTH\"");
-	   doit("DOCPROPERTY", data, "\"Mary SmiTH\"");
-	} 
-	 
-	@Test
-	public void testNone10() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "\"mary SmiTH\"");
-	   doit("MERGEFIELD", data, "\"mary SmiTH\"");
-	   doit("DOCPROPERTY", data, "\"mary SmiTH\"");
-	} 
-	 
-	@Test
-	public void testNone11() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "mary smith");
-	   doit("MERGEFIELD", data, "mary smith");
-	   doit("DOCPROPERTY", data, "mary smith");
-	} 
-	 
-	@Test
-	public void testNone12() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "Mary SmiTH");
-	   doit("MERGEFIELD", data, "Mary SmiTH");
-	   doit("DOCPROPERTY", data, "Mary SmiTH");
-	} 
-	 
-	@Test
-	public void testNone13() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "\"mary smith\"");
-	   doit("MERGEFIELD", data, "\"mary smith\"");
-	   doit("DOCPROPERTY", data, "\"mary smith\"");
-	} 
-	 
-	@Test
-	public void testNone14() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "01");
-	   doit("MERGEFIELD", data, "01");
-	   doit("DOCPROPERTY", data, "01");
-	} 
-	 
-	@Test
-	public void testNone15() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "0.1");
-	   doit("MERGEFIELD", data, "0.1");
-	   doit("DOCPROPERTY", data, "0.1");
-	} 
-	 
-	@Test
-	public void testNone16() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "0.0");
-	   doit("MERGEFIELD", data, "0.0");
-	   doit("DOCPROPERTY", data, "0.0");
-	} 
-	 
-	@Test
-	public void testNone17() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "0.00");
-	   doit("MERGEFIELD", data, "0.00");
-	   doit("DOCPROPERTY", data, "0.00");
-	} 
-	 
-	@Test
-	public void testNone18() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "0.");
-	   doit("MERGEFIELD", data, "0.");
-	   doit("DOCPROPERTY", data, "0.");
-	} 
-	 
-	@Test
-	public void testNone19() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "\"0.1 A\"");
-	   doit("MERGEFIELD", data, "\"0.1 A\"");
-	   doit("DOCPROPERTY", data, "\"0.1 A\"");
-	} 
-	 
-	@Test
-	public void testNone20() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "\"0.1 1\"");
-	   doit("MERGEFIELD", data, "\"0.1 1\"");
-	   doit("DOCPROPERTY", data, "\"0.1 1\"");
-	} 
-	 
-	@Test
-	public void testNone21() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "\"0.1 .\"");
-	   doit("MERGEFIELD", data, "\"0.1 .\"");
-	   doit("DOCPROPERTY", data, "\"0.1 .\"");
-	} 
-	 
-	@Test
-	public void testNone22() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "\"0.00 0\"");
-	   doit("MERGEFIELD", data, "\"0.00 0\"");
-	   doit("DOCPROPERTY", data, "\"0.00 0\"");
-	} 
-	 
-	@Test
-	public void testNone23() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "\"0.00 1\"");
-	   doit("MERGEFIELD", data, "\"0.00 1\"");
-	   doit("DOCPROPERTY", data, "\"0.00 1\"");
-	} 
-	 
-	@Test
-	public void testNone24() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "\"0.00 A\"");
-	   doit("MERGEFIELD", data, "\"0.00 A\"");
-	   doit("DOCPROPERTY", data, "\"0.00 A\"");
-	} 
-	 
-	@Test
-	public void testNone25() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "0.1 A");
-	   doit("MERGEFIELD", data, "0.1 A");
-	   doit("DOCPROPERTY", data, "0.1 A");
-	} 
-	 
-	@Test
-	public void testNone26() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "0.1 1");
-	   doit("MERGEFIELD", data, "0.1 1");
-	   doit("DOCPROPERTY", data, "0.1 1");
-	} 
-	 
-	@Test
-	public void testNone27() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "0.1 .");
-	   doit("MERGEFIELD", data, "0.1 .");
-	   doit("DOCPROPERTY", data, "0.1 .");
-	} 
-	 
-	@Test
-	public void testNone28() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "0.00 0");
-	   doit("MERGEFIELD", data, "0.00 0");
-	   doit("DOCPROPERTY", data, "0.00 0");
-	} 
-	 
-	@Test
-	public void testNone29() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "0.00 1");
-	   doit("MERGEFIELD", data, "0.00 1");
-	   doit("DOCPROPERTY", data, "0.00 1");
-	} 
-	 
-	@Test
-	public void testNone30() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "0.00 A");
-	   doit("MERGEFIELD", data, "0.00 A");
-	   doit("DOCPROPERTY", data, "0.00 A");
-	} 
-	 
-	@Test
-	public void testNone31() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "0000123456");
-	   doit("MERGEFIELD", data, "0000123456");
-	   doit("DOCPROPERTY", data, "0000123456");
-	} 
-	 
-	@Test
-	public void testNone32() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "000012345.006");
-	   doit("MERGEFIELD", data, "000012345.006");
-	   doit("DOCPROPERTY", data, "000012345.006");
-	} 
-	 
-	@Test
-	public void testNone33() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "0000123AA456");
-	   doit("MERGEFIELD", data, "0000123AA456");
-	   doit("DOCPROPERTY", data, "0000123AA456");
-	} 
-	 
-	@Test
-	public void testNone34() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "0000123AA45.006");
-	   doit("MERGEFIELD", data, "0000123AA45.006");
-	   doit("DOCPROPERTY", data, "0000123AA45.006");
-	} 
-	 
-	@Test
-	public void testNone35() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "123");
-	   doit("MERGEFIELD", data, "123");
-	   doit("DOCPROPERTY", data, "123");
-	} 
-	 
-	@Test
-	public void testNone36() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "-123");
-	   doit("MERGEFIELD", data, "-123");
-	   doit("DOCPROPERTY", data, "-123");
-	} 
-	 
-	@Test
-	public void testNone37() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "123.");
-	   doit("MERGEFIELD", data, "123.");
-	   doit("DOCPROPERTY", data, "123.");
-	} 
-	 
-	@Test
-	public void testNone38() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "-123.");
-	   doit("MERGEFIELD", data, "-123.");
-	   doit("DOCPROPERTY", data, "-123.");
-	} 
-	 
-	@Test
-	public void testNone39() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "0");
-	   doit("MERGEFIELD", data, "0");
-	   doit("DOCPROPERTY", data, "0");
-	} 
-	 
-	@Test
-	public void testNone40() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "00");
-	   doit("MERGEFIELD", data, "00");
-	   doit("DOCPROPERTY", data, "00");
-	} 
-	 
-	@Test
-	public void testNone41() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "0.");
-	   doit("MERGEFIELD", data, "0.");
-	   doit("DOCPROPERTY", data, "0.");
-	} 
-	 
-	@Test
-	public void testNone42() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "01");
-	   doit("MERGEFIELD", data, "01");
-	   doit("DOCPROPERTY", data, "01");
-	} 
-	 
-	@Test
-	public void testNone43() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "0.1");
-	   doit("MERGEFIELD", data, "0.1");
-	   doit("DOCPROPERTY", data, "0.1");
-	} 
-	 
-	@Test
-	public void testNone44() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "0.0");
-	   doit("MERGEFIELD", data, "0.0");
-	   doit("DOCPROPERTY", data, "0.0");
-	} 
-	 
-	@Test
-	public void testNone45() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "0.00");
-	   doit("MERGEFIELD", data, "0.00");
-	   doit("DOCPROPERTY", data, "0.00");
-	} 
-	 
-	@Test
-	public void testNone46() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "0.00 0");
-	   doit("MERGEFIELD", data, "0.00 0");
-	   doit("DOCPROPERTY", data, "0.00 0");
-	} 
-	 
-	@Test
-	public void testNone47() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "0.00 1");
-	   doit("MERGEFIELD", data, "0.00 1");
-	   doit("DOCPROPERTY", data, "0.00 1");
-	} 
-	 
-	@Test
-	public void testNone48() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "0.00 A");
-	   doit("MERGEFIELD", data, "0.00 A");
-	   doit("DOCPROPERTY", data, "0.00 A");
-	} 
-	 
-	@Test
-	public void testNone49() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "0.00 W");
-	   doit("MERGEFIELD", data, "0.00 W");
-	   doit("DOCPROPERTY", data, "0.00 W");
-	} 
-	 
-	@Test
-	public void testNone50() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "\"01\"");
-	   doit("MERGEFIELD", data, "\"01\"");
-	   doit("DOCPROPERTY", data, "\"01\"");
-	} 
-	 
-	@Test
-	public void testNone51() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "\"0.1\"");
-	   doit("MERGEFIELD", data, "\"0.1\"");
-	   doit("DOCPROPERTY", data, "\"0.1\"");
-	} 
-	 
-	@Test
-	public void testNone52() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "\"0.0\"");
-	   doit("MERGEFIELD", data, "\"0.0\"");
-	   doit("DOCPROPERTY", data, "\"0.0\"");
-	} 
-	 
-	@Test
-	public void testNone53() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "\"0.00\"");
-	   doit("MERGEFIELD", data, "\"0.00\"");
-	   doit("DOCPROPERTY", data, "\"0.00\"");
-	} 
-	 
-	@Test
-	public void testNone54() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "\"0.00 0\"");
-	   doit("MERGEFIELD", data, "\"0.00 0\"");
-	   doit("DOCPROPERTY", data, "\"0.00 0\"");
-	} 
-	 
-	@Test
-	public void testNone55() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "\"0.00 1\"");
-	   doit("MERGEFIELD", data, "\"0.00 1\"");
-	   doit("DOCPROPERTY", data, "\"0.00 1\"");
-	} 
-	 
-	@Test
-	public void testNone56() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "\"0.00 A\"");
-	   doit("MERGEFIELD", data, "\"0.00 A\"");
-	   doit("DOCPROPERTY", data, "\"0.00 A\"");
-	} 
-	 
-	@Test
-	public void testNone57() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "\"0.00 W\"");
-	   doit("MERGEFIELD", data, "\"0.00 W\"");
-	   doit("DOCPROPERTY", data, "\"0.00 W\"");
-	} 
-	 
-	@Test
-	public void testNone58() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "0000123456");
-	   doit("MERGEFIELD", data, "0000123456");
-	   doit("DOCPROPERTY", data, "0000123456");
-	} 
-	 
-	@Test
-	public void testNone59() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "000012345.006");
-	   doit("MERGEFIELD", data, "000012345.006");
-	   doit("DOCPROPERTY", data, "000012345.006");
-	} 
-	 
-	@Test
-	public void testNone60() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "0000123AA456");
-	   doit("MERGEFIELD", data, "0000123AA456");
-	   doit("DOCPROPERTY", data, "0000123AA456");
-	} 
-	 
-	@Test
-	public void testNone61() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("", "0000123AA45.006");
-	   doit("MERGEFIELD", data, "0000123AA45.006");
-	   doit("DOCPROPERTY", data, "0000123AA45.006");
-	} 
 
-	
-	
+	// In all cases, output = input
+
+	@Parameterized.Parameter(value=0)
+	public String value;
+
+	@Parameterized.Parameters(name = "{index}: test {0} parsed as is")
+	public static Collection<Object[]> data() {
+		return Arrays.asList(new Object[][]{
+				{"mary smith"},
+				{"mary\"smith"},
+				{"\"mary smith\""},
+				{"\"marysmith\""},
+				{"\"mary smith\""},
+				{"\"Mary Smith\""},
+				{"\"Mary Smith\""},
+				{"\"Mary Smith\" Capoop"},
+				{"\"Mary SmiTH\""},
+				{"\"mary SmiTH\""},
+				{"mary smith"},
+				{"Mary SmiTH"},
+				{"\"mary smith\""},
+				{"01"},
+				{"0.1"},
+				{"0.0"},
+				{"0.00"},
+				{"0."},
+				{"\"0.1 A\""},
+				{"\"0.1 1\""},
+				{"\"0.1 .\""},
+				{"\"0.00 0\""},
+				{"\"0.00 1\""},
+				{"\"0.00 A\""},
+				{"0.1 A"},
+				{"0.1 1"},
+				{"0.1 ."},
+				{"0.00 0"},
+				{"0.00 1"},
+				{"0.00 A"},
+				{"0000123456"},
+				{"000012345.006"},
+				{"0000123AA456"},
+				{"0000123AA45.006"},
+				{"123"},
+				{"-123"},
+				{"123."},
+				{"-123."},
+				{"0"},
+				{"00"},
+				{"0."},
+				{"01"},
+				{"0.1"},
+				{"0.0"},
+				{"0.00"},
+				{"0.00 0"},
+				{"0.00 1"},
+				{"0.00 A"},
+				{"0.00 W"},
+				{"\"01\""},
+				{"\"0.1\""},
+				{"\"0.0\""},
+				{"\"0.00\""},
+				{"\"0.00 0\""},
+				{"\"0.00 1\""},
+				{"\"0.00 A\""},
+				{"\"0.00 W\""},
+				{"0000123456"},
+				{"000012345.006"},
+				{"0000123AA456"},
+				{"0000123AA45.006"}
+		});
+	}
+
+	@Test
+	public void testDataParsedAsIs()  throws TransformerException, Docx4JException {
+		SwitchTestData data = new SwitchTestData("", value);
+		doit("MERGEFIELD", data, value);
+		doit("DOCPROPERTY", data, value);
+	}
+
+
 	// ---------------------------------------------------------------------------------------
-	
+
 	private void doit(String fieldname, SwitchTestData triple, String expectedResult)  throws TransformerException, Docx4JException {
-		
+
 		String instr = fieldname + " foo " + triple.format;
 		String result = getFormat(instr, triple.val);
-		System.out.println(result);
 		assertTrue(result.equals(expectedResult));
 	}
-	
+
 	private String getFormat(String instr, String val) throws TransformerException, Docx4JException {
-			
+
 		FldSimpleModel fsm = new FldSimpleModel();
 		fsm.build(instr);
-		return FormattingSwitchHelper.applyFormattingSwitch(null, fsm, val);		
+		return FormattingSwitchHelper.applyFormattingSwitch(null, fsm, val);
 	}
-		
+
 	private static class SwitchTestData {
 
 		String format;
 		String val;
-		
+
 		public String toString() {
 			return "format " + format + " to data " + val;
 		}
@@ -472,6 +126,6 @@ public class FormattingSwitchHelperNoSwitchTests {
 			this.val = val;
 		}
 	}
-	
-	
+
+
 }

--- a/src/test/java/org/docx4j/model/fields/FormattingSwitchHelperNoSwitchTests.java
+++ b/src/test/java/org/docx4j/model/fields/FormattingSwitchHelperNoSwitchTests.java
@@ -13,7 +13,7 @@ import java.util.Arrays;
 import java.util.Collection;
 
 @RunWith(value = Parameterized.class)
-public class FormattingSwitchHelperNoSwitchTests {
+public class FormattingSwitchHelperNoSwitchTests extends FormattingTestsBase{
 
 	// In all cases, output = input
 
@@ -93,39 +93,4 @@ public class FormattingSwitchHelperNoSwitchTests {
 		doit("MERGEFIELD", data, value);
 		doit("DOCPROPERTY", data, value);
 	}
-
-
-	// ---------------------------------------------------------------------------------------
-
-	private void doit(String fieldname, SwitchTestData triple, String expectedResult)  throws TransformerException, Docx4JException {
-
-		String instr = fieldname + " foo " + triple.format;
-		String result = getFormat(instr, triple.val);
-		assertTrue(result.equals(expectedResult));
-	}
-
-	private String getFormat(String instr, String val) throws TransformerException, Docx4JException {
-
-		FldSimpleModel fsm = new FldSimpleModel();
-		fsm.build(instr);
-		return FormattingSwitchHelper.applyFormattingSwitch(null, fsm, val);
-	}
-
-	private static class SwitchTestData {
-
-		String format;
-		String val;
-
-		public String toString() {
-			return "format " + format + " to data " + val;
-		}
-
-		public SwitchTestData(String format, String val) {
-
-			this.format = format;
-			this.val = val;
-		}
-	}
-
-
 }

--- a/src/test/java/org/docx4j/model/fields/FormattingSwitchHelperNumericTests.java
+++ b/src/test/java/org/docx4j/model/fields/FormattingSwitchHelperNumericTests.java
@@ -1,689 +1,140 @@
 package org.docx4j.model.fields;
 
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import javax.xml.transform.TransformerException;
 
 import org.docx4j.openpackaging.exceptions.Docx4JException;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Locale;
+
+@RunWith(value = Parameterized.class)
 public class FormattingSwitchHelperNumericTests {
-	
-	
-	@Test
-	public void testNumberNotSpecified() throws TransformerException, Docx4JException {
-		// \# without arg results in Error! Switch argument not specified.
-		   SwitchTestData data = new SwitchTestData("\\# ", "123");
-		   doit("MERGEFIELD", data, "Error! Switch argument not specified.");
-		   doit("DOCPROPERTY", data, "Error! Switch argument not specified.");
+
+	static Locale initialLocale;
+
+	@BeforeClass
+	public static void setUpBeforeClass() throws Exception {
+		initialLocale=Locale.getDefault();
+		Locale.setDefault(Locale.ENGLISH); // decimal delimiter is different in another locale
 	}
-	
-	@Test
-	public void testNumber31() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\# 00.00", "9");
-	   doit("MERGEFIELD", data, "09.00");
-	   doit("DOCPROPERTY", data, "09.00");
-	} 
-	 
-	@Test
-	public void testNumber32() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\# 00.00", "9.006");
-	   doit("MERGEFIELD", data, "09.01");
-	   doit("DOCPROPERTY", data, "09.01");
-	} 
-	 
-	@Test
-	public void testNumber33() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\# $###", "15");
-	   doit("MERGEFIELD", data, "$15");
-	   doit("DOCPROPERTY", data, "$15");
-	} 
-	 
-	@Test
-	public void testNumber34() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\# ##.##", "9");
-	   doit("MERGEFIELD", data, "9");
-	   doit("DOCPROPERTY", data, "9");
-	} 
-	 
-	@Test
-	public void testNumber35() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\# ##.##", "9.006");
-	   doit("MERGEFIELD", data, "9.01");
-	   doit("DOCPROPERTY", data, "9.01");
-	} 
-	 
-	@Test
-	public void testNumber36() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\# ##.##0000", "9.006");
-	   doit("MERGEFIELD", data, "9.006");
-	   doit("DOCPROPERTY", data, "9.006");
-	} 
-	 
-	@Test
-	public void testNumber37() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\# ##.##00#0", "9.006");
-	   doit("MERGEFIELD", data, "9.006");
-	   doit("DOCPROPERTY", data, "9.006");
-	} 
-	 
-	@Test
-	public void testNumber38() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\# ####.0000", "123.456");
-	   doit("MERGEFIELD", data, "123.4560");
-	   doit("DOCPROPERTY", data, "123.4560");
-	} 
-	 
-	@Test
-	public void testNumber39() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\# 0000.####", "123.456");
-	   doit("MERGEFIELD", data, "0123.456");
-	   doit("DOCPROPERTY", data, "0123.456");
-	} 
-	 
-	@Test
-	public void testNumber40() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\# #.0000", "123.456");
-	   doit("MERGEFIELD", data, "123.4560");
-	   doit("DOCPROPERTY", data, "123.4560");
-	} 
-	 
-	@Test
-	public void testNumber41() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\# 0.####", "123.456");
-	   doit("MERGEFIELD", data, "123.456");
-	   doit("DOCPROPERTY", data, "123.456");
-	} 
-	 
-	 
-	@Test
-	public void testNumber44() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\# 0.00x", "0.125678");
-	   doit("MERGEFIELD", data, "0.126");
-	   doit("DOCPROPERTY", data, "0.126");
-	} 
-	 
-	@Test
-	public void testNumber45() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\# .x", "0.75");
-	   doit("MERGEFIELD", data, ".8");
-	   doit("DOCPROPERTY", data, ".8");
-	} 
-	 
-	@Test
-	public void testNumber46() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\# .000x", "0.75");
-	   doit("MERGEFIELD", data, ".7500");
-	   doit("DOCPROPERTY", data, ".7500");
-	} 
-	 
-	@Test
-	public void testNumber47() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\# .###x", "0.75");
-	   doit("MERGEFIELD", data, ".75");
-	   doit("DOCPROPERTY", data, ".75");
-	} 
-	 
-	@Test
-	public void testNumber48() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\# .###x", ".75");
-	   doit("MERGEFIELD", data, ".75");
-	   doit("DOCPROPERTY", data, ".75");
-	} 
-	 
-	 
-	@Test
-	public void testNumber55() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\# 0.00xx", "0.125678");
-	   doit("MERGEFIELD", data, "0.1257");
-	   doit("DOCPROPERTY", data, "0.1257");
-	} 
-	 
-	@Test
-	public void testNumber56() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\# 0.x0x", "0.125678");
-	   doit("MERGEFIELD", data, "0.126");
-	   doit("DOCPROPERTY", data, "0.126");
-	} 
-	 
-	@Test
-	public void testNumber57() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\# $###.00", "95.4");
-	   doit("MERGEFIELD", data, "$95.40");
-	   doit("DOCPROPERTY", data, "$95.40");
-	} 
-	 
-	 
-	@Test
-	public void testNumber60() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\# $#,###,###", "2456800");
-	   doit("MERGEFIELD", data, "$2,456,800");
-	   doit("DOCPROPERTY", data, "$2,456,800");
-	} 
-	 
-	@Test
-	public void testNumber61() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\# -##", "-10");
-	   doit("MERGEFIELD", data, "-10");
-	   doit("DOCPROPERTY", data, "-10");
-	} 
-	 
-	@Test
-	public void testNumber62() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\# -##", "10");
-	   doit("MERGEFIELD", data, "10");
-	   doit("DOCPROPERTY", data, "10");
-	} 
-	 
-	@Test
-	public void testNumber63() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\# +##", "10");
-	   doit("MERGEFIELD", data, "10");
-	   doit("DOCPROPERTY", data, "10");
-	} 
-	 
-	@Test
-	public void testNumber64() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\# +##", "-10");
-	   doit("MERGEFIELD", data, "-10");
-	   doit("DOCPROPERTY", data, "-10");
-	} 
-	 
-	@Test
-	public void testNumber65() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\# ##%", "33");
-	   doit("MERGEFIELD", data, "33%");
-	   doit("DOCPROPERTY", data, "33%");
-	} 
-	 
-	 
-	@Test
-	public void testNumber68() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\# \"$##0.00 'is the sales tax'\"", "3.89");
-	   doit("MERGEFIELD", data, "$3.89 is the sales tax");
-	   doit("DOCPROPERTY", data, "$3.89 is the sales tax");
-	} 
-	 
-	@Test
-	public void testNumber69() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\# \"$##0.00 'is the ##.00 goodness'\"", "3.89");
-	   doit("MERGEFIELD", data, "$3.89 is the ##.00 goodness");
-	   doit("DOCPROPERTY", data, "$3.89 is the ##.00 goodness");
-	} 
-	 
-	@Test
-	public void testNumber70() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\# \"$##0.00 is the '##.00' goodness\"", "3.89");
-	   doit("MERGEFIELD", data, "$3.89 is the ##.00 goodness");
-	   doit("DOCPROPERTY", data, "$3.89 is the ##.00 goodness");
-	} 
-	 
-	 
-	@Test
-	public void testNumber72() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\# 00", "€180,000.00 EUR");
-	   doit("MERGEFIELD", data, "180000");
-	   doit("DOCPROPERTY", data, "180000");
-	} 
 
-
-	
-	@Test
-	public void testNumber42() throws TransformerException, Docx4JException {
-		SwitchTestData data = new SwitchTestData("\\# x#.#x", "123456");
-		try {
-			doit("MERGEFIELD", data, "class org.docx4j.model.fields.FieldFormattingException");
-		} catch (Exception e) {
-			System.out.println("[" + data.toString() + "] " + e.getMessage());
-			assertTrue(FieldFormattingException.class.isAssignableFrom(e.getClass()));
-		}
-		try {
-			doit("DOCPROPERTY", data, "class org.docx4j.model.fields.FieldFormattingException");
-		} catch (Exception e) {
-			System.out.println("[" + data.toString() + "] " + e.getMessage());
-			assertTrue(FieldFormattingException.class.isAssignableFrom(e.getClass()));
-		}
+	@AfterClass
+	public static void tearDownAfterClass() throws Exception {
+		Locale.setDefault(initialLocale);
 	}
-	 
-	@Test
-	public void testNumber43() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\# x#.#x", "123.456");
-		try {
-			doit("MERGEFIELD", data, "class org.docx4j.model.fields.FieldFormattingException");
-		} catch (Exception e) {
-			System.out.println("[" + data.toString() + "] " + e.getMessage());
-			assertTrue(FieldFormattingException.class.isAssignableFrom(e.getClass()));
-		}
-		try {
-			doit("DOCPROPERTY", data, "class org.docx4j.model.fields.FieldFormattingException");
-		} catch (Exception e) {
-			System.out.println("[" + data.toString() + "] " + e.getMessage());
-			assertTrue(FieldFormattingException.class.isAssignableFrom(e.getClass()));
-		}
-	} 
-	@Test
-	public void testNumber49() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\# .###x", "-0.75");
-		try {
-			doit("MERGEFIELD", data, "class org.docx4j.model.fields.FieldFormattingException");
-		} catch (Exception e) {
-			System.out.println("[" + data.toString() + "] " + e.getMessage());
-			assertTrue(FieldFormattingException.class.isAssignableFrom(e.getClass()));
-		}
-		try {
-			doit("DOCPROPERTY", data, "class org.docx4j.model.fields.FieldFormattingException");
-		} catch (Exception e) {
-			System.out.println("[" + data.toString() + "] " + e.getMessage());
-			assertTrue(FieldFormattingException.class.isAssignableFrom(e.getClass()));
-		}
-	} 
-	 
-	@Test
-	public void testNumber50() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\# .###x", "-.75");
-		try {
-			doit("MERGEFIELD", data, "class org.docx4j.model.fields.FieldFormattingException");
-		} catch (Exception e) {
-			System.out.println("[" + data.toString() + "] " + e.getMessage());
-			assertTrue(FieldFormattingException.class.isAssignableFrom(e.getClass()));
-		}
-		try {
-			doit("DOCPROPERTY", data, "class org.docx4j.model.fields.FieldFormattingException");
-		} catch (Exception e) {
-			System.out.println("[" + data.toString() + "] " + e.getMessage());
-			assertTrue(FieldFormattingException.class.isAssignableFrom(e.getClass()));
-		}
-	} 
-	 
-	@Test
-	public void testNumber51() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\# .###", "-0.75");
-		try {
-			doit("MERGEFIELD", data, "class org.docx4j.model.fields.FieldFormattingException");
-		} catch (Exception e) {
-			System.out.println("[" + data.toString() + "] " + e.getMessage());
-			assertTrue(FieldFormattingException.class.isAssignableFrom(e.getClass()));
-		}
-		try {
-			doit("DOCPROPERTY", data, "class org.docx4j.model.fields.FieldFormattingException");
-		} catch (Exception e) {
-			System.out.println("[" + data.toString() + "] " + e.getMessage());
-			assertTrue(FieldFormattingException.class.isAssignableFrom(e.getClass()));
-		}
-	} 
-	 
-	@Test
-	public void testNumber52() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\# .###", "-.75");
-		try {
-			doit("MERGEFIELD", data, "class org.docx4j.model.fields.FieldFormattingException");
-		} catch (Exception e) {
-			System.out.println("[" + data.toString() + "] " + e.getMessage());
-			assertTrue(FieldFormattingException.class.isAssignableFrom(e.getClass()));
-		}
-		try {
-			doit("DOCPROPERTY", data, "class org.docx4j.model.fields.FieldFormattingException");
-		} catch (Exception e) {
-			System.out.println("[" + data.toString() + "] " + e.getMessage());
-			assertTrue(FieldFormattingException.class.isAssignableFrom(e.getClass()));
-		}
-	} 
-	 
-	@Test
-	public void testNumber53() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\# .000", "-0.75");
-		try {
-			doit("MERGEFIELD", data, "class org.docx4j.model.fields.FieldFormattingException");
-		} catch (Exception e) {
-			System.out.println("[" + data.toString() + "] " + e.getMessage());
-			assertTrue(FieldFormattingException.class.isAssignableFrom(e.getClass()));
-		}
-		try {
-			doit("DOCPROPERTY", data, "class org.docx4j.model.fields.FieldFormattingException");
-		} catch (Exception e) {
-			System.out.println("[" + data.toString() + "] " + e.getMessage());
-			assertTrue(FieldFormattingException.class.isAssignableFrom(e.getClass()));
-		}
-	} 
-	 
-	@Test
-	public void testNumber54() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\# .000", "-.75");
-		try {
-			doit("MERGEFIELD", data, "class org.docx4j.model.fields.FieldFormattingException");
-		} catch (Exception e) {
-			System.out.println("[" + data.toString() + "] " + e.getMessage());
-			assertTrue(FieldFormattingException.class.isAssignableFrom(e.getClass()));
-		}
-		try {
-			doit("DOCPROPERTY", data, "class org.docx4j.model.fields.FieldFormattingException");
-		} catch (Exception e) {
-			System.out.println("[" + data.toString() + "] " + e.getMessage());
-			assertTrue(FieldFormattingException.class.isAssignableFrom(e.getClass()));
-		}
-	} 
-	
-	@Test
-	public void testNumber58() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\# .00", "95.4");
-		try {
-			doit("MERGEFIELD", data, "class org.docx4j.model.fields.FieldFormattingException");
-		} catch (Exception e) {
-			System.out.println("[" + data.toString() + "] " + e.getMessage());
-			assertTrue(FieldFormattingException.class.isAssignableFrom(e.getClass()));
-		}
-		try {
-			doit("DOCPROPERTY", data, "class org.docx4j.model.fields.FieldFormattingException");
-		} catch (Exception e) {
-			System.out.println("[" + data.toString() + "] " + e.getMessage());
-			assertTrue(FieldFormattingException.class.isAssignableFrom(e.getClass()));
-		}
-	} 
-	 
-	@Test
-	public void testNumber59() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\# .##", "95.4");
-		try {
-			doit("MERGEFIELD", data, "class org.docx4j.model.fields.FieldFormattingException");
-		} catch (Exception e) {
-			System.out.println("[" + data.toString() + "] " + e.getMessage());
-			assertTrue(FieldFormattingException.class.isAssignableFrom(e.getClass()));
-		}
-		try {
-			doit("DOCPROPERTY", data, "class org.docx4j.model.fields.FieldFormattingException");
-		} catch (Exception e) {
-			System.out.println("[" + data.toString() + "] " + e.getMessage());
-			assertTrue(FieldFormattingException.class.isAssignableFrom(e.getClass()));
-		}
-	} 
-	
-	@Test
-	public void testNumber66() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\# #%#", "33");
-		try {
-			doit("MERGEFIELD", data, "class org.docx4j.model.fields.FieldFormattingException");
-		} catch (Exception e) {
-			System.out.println("[" + data.toString() + "] " + e.getMessage());
-			assertTrue(FieldFormattingException.class.isAssignableFrom(e.getClass()));
-		}
-		try {
-			doit("DOCPROPERTY", data, "class org.docx4j.model.fields.FieldFormattingException");
-		} catch (Exception e) {
-			System.out.println("[" + data.toString() + "] " + e.getMessage());
-			assertTrue(FieldFormattingException.class.isAssignableFrom(e.getClass()));
-		}
-	} 
-	 
-	@Test
-	public void testNumber67() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\# #$#", "33");
-		try {
-			doit("MERGEFIELD", data, "class org.docx4j.model.fields.FieldFormattingException");
-		} catch (Exception e) {
-			System.out.println("[" + data.toString() + "] " + e.getMessage());
-			assertTrue(FieldFormattingException.class.isAssignableFrom(e.getClass()));
-		}
-		try {
-			doit("DOCPROPERTY", data, "class org.docx4j.model.fields.FieldFormattingException");
-		} catch (Exception e) {
-			System.out.println("[" + data.toString() + "] " + e.getMessage());
-			assertTrue(FieldFormattingException.class.isAssignableFrom(e.getClass()));
-		}
-	} 
-	
-	@Test
-	public void testNumber71() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\# #'y'#", "34");
-		try {
-			doit("MERGEFIELD", data, "class org.docx4j.model.fields.FieldFormattingException");
-		} catch (Exception e) {
-			System.out.println("[" + data.toString() + "] " + e.getMessage());
-			assertTrue(FieldFormattingException.class.isAssignableFrom(e.getClass()));
-		}
-		try {
-			doit("DOCPROPERTY", data, "class org.docx4j.model.fields.FieldFormattingException");
-		} catch (Exception e) {
-			System.out.println("[" + data.toString() + "] " + e.getMessage());
-			assertTrue(FieldFormattingException.class.isAssignableFrom(e.getClass()));
-		}
-	} 
-	
 
-	// All these should return Error! Switch argument not specified.
-	
+	@Parameterized.Parameter(value=0)
+	public String format;
+
+	@Parameterized.Parameter(value=1)
+	public String input;
+
+	@Parameterized.Parameter(value=2)
+	public String result;
+
+	@Parameterized.Parameters(name = "{index}: test {1}({0}) parsed as {2}")
+	public static Collection<Object[]> data() {
+		return Arrays.asList(new Object[][]{
+				{"\\# ", "123","Error! Switch argument not specified."},
+				{"\\# 00.00", "9","09.00"},
+				{"\\# 00.00", "9.006","09.01"},
+				{"\\# $###", "15","$15"},
+				{"\\# ##.##", "9","9"},
+				{"\\# ##.##", "9.006","9.01"},
+				{"\\# ##.##0000", "9.006","9.006"},
+				{"\\# ##.##00#0", "9.006","9.006"},
+				{"\\# ####.0000", "123.456","123.4560"},
+				{"\\# 0000.####", "123.456","0123.456"},
+				{"\\# #.0000", "123.456","123.4560"},
+				{"\\# 0.####", "123.456","123.456"},
+				{"\\# 0.00x", "0.125678","0.126"},
+				{"\\# .x", "0.75",".8"},
+				{"\\# .000x", "0.75",".7500"},
+				{"\\# .###x", "0.75",".75"},
+				{"\\# .###x", ".75",".75"},
+				{"\\# 0.00xx", "0.125678","0.1257"},
+				{"\\# 0.x0x", "0.125678","0.126"},
+				{"\\# $###.00", "95.4","$95.40"},
+				{"\\# $#,###,###", "2456800","$2,456,800"},
+				{"\\# -##", "-10","-10"},
+				{"\\# -##", "10","10"},
+				{"\\# +##", "10","10"},
+				{"\\# +##", "-10","-10"},
+				{"\\# ##%", "33","33%"},
+				{"\\# \"$##0.00 'is the sales tax'\"", "3.89","$3.89 is the sales tax"},
+				{"\\# \"$##0.00 'is the ##.00 goodness'\"", "3.89","$3.89 is the ##.00 goodness"},
+				{"\\# \"$##0.00 is the '##.00' goodness\"", "3.89","$3.89 is the ##.00 goodness"},
+				{"\\# 00", "€180,000.00 EUR","180000"}
+		});
+	}
+
+	// following assertions were commented out. To test it, add following parameters:
+	//{"\\# ", "-123.4500","-123.4500"},
+	//{"\\# ", "123","123"},
+	//{"\\# ", "-123","-123"},
+	//{"\\# ", "123.","123"},
+	//{"\\# ", "-123.","-123"},
+	//{"\\# ", "0","0"},
+	//{"\\# ", "00","00"},
+	//{"\\# ", "0.","0"},
+	//{"\\# ", "01","01"},
+	//{"\\# ", "0.1","0.1"},
+	//{"\\# ", "0.0","0.0"},
+	//{"\\# ", "0.00","0.00"},
+	//{"\\# ", "0.00 0","0.00 0"},
+	//{"\\# ", "0.00 1","0.00 1"},
+	//{"\\# ", "0.00 A","0.00 A"},
+	//{"\\# ", "0.00 W","0.00 W"},
+	//{"\\# ", "\"01\"","01"},
+	//{"\\# ", "\"0.1\"","0.1"},
+	//{"\\# ", "\"0.0\"","0.0"},
+	//{"\\# ", "\"0.00\"","0.00"},
+	//{"\\# ", "\"0.00 0\"","0.00 0"},
+	//{"\\# ", "\"0.00 1\"","0.00 1"},
+	//{"\\# ", "\"0.00 A\"","0.00 A"},
+	//{"\\# ", "\"0.00 W\"","0.00 W"},
+	//{"\\# ", "0000123456","0000123456"},
+	//{"\\# ", "000012345.006","000012345.006"},
+	//{"\\# ", "0000123AA456","0000123AA456"},
+	//{"\\# ", "0000123AA45.006","0000123AA45.006"}
+
 	@Test
-	public void testNumber1() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\# ", "AA");
-	   doit("MERGEFIELD", data, "Error! Switch argument not specified.");  
-	   doit("DOCPROPERTY", data, "Error! Switch argument not specified.");
-	} 
-	 
-	@Test
-	public void testNumber2() throws TransformerException, Docx4JException {
-	   SwitchTestData data = new SwitchTestData("\\# ", "123.4500");
-	   doit("MERGEFIELD", data, "Error! Switch argument not specified.");
-	   doit("DOCPROPERTY", data, "Error! Switch argument not specified.");
-	} 
-//	 
-//	@Test
-//	public void testNumber3() throws TransformerException, Docx4JException {
-//	   SwitchTestData data = new SwitchTestData("\\# ", "-123.4500");
-//	   doit("MERGEFIELD", data, "-123.4500");
-//	   doit("DOCPROPERTY", data, "-123.4500");
-//	} 
-//	 
-//	@Test
-//	public void testNumber4() throws TransformerException, Docx4JException {
-//	   SwitchTestData data = new SwitchTestData("\\# ", "123");
-//	   doit("MERGEFIELD", data, "123");
-//	   doit("DOCPROPERTY", data, "123");
-//	} 
-//	 
-//	@Test
-//	public void testNumber5() throws TransformerException, Docx4JException {
-//	   SwitchTestData data = new SwitchTestData("\\# ", "-123");
-//	   doit("MERGEFIELD", data, "-123");
-//	   doit("DOCPROPERTY", data, "-123");
-//	} 
-//	 
-//	@Test
-//	public void testNumber6() throws TransformerException, Docx4JException {
-//	   SwitchTestData data = new SwitchTestData("\\# ", "123.");
-//	   doit("MERGEFIELD", data, "123");
-//	   doit("DOCPROPERTY", data, "123."); // NB result is different
-//	} 
-//	 
-//	@Test
-//	public void testNumber7() throws TransformerException, Docx4JException {
-//	   SwitchTestData data = new SwitchTestData("\\# ", "-123.");
-//	   doit("MERGEFIELD", data, "-123");
-//	   doit("DOCPROPERTY", data, "-123."); // NB result is different
-//	} 
-//	 
-//	@Test
-//	public void testNumber8() throws TransformerException, Docx4JException {
-//	   SwitchTestData data = new SwitchTestData("\\# ", "0");
-//	   doit("MERGEFIELD", data, "0");
-//	   doit("DOCPROPERTY", data, "0");
-//	} 
-//	 
-//	@Test
-//	public void testNumber9() throws TransformerException, Docx4JException {
-//	   SwitchTestData data = new SwitchTestData("\\# ", "00");
-//	   doit("MERGEFIELD", data, "00");
-//	   doit("DOCPROPERTY", data, "00");
-//	} 
-//	 
-//	@Test
-//	public void testNumber10() throws TransformerException, Docx4JException {
-//	   SwitchTestData data = new SwitchTestData("\\# ", "0.");
-//	   doit("MERGEFIELD", data, "0");
-//	   doit("DOCPROPERTY", data, "0.");  // NB result is different
-//	} 
-//	 
-//	@Test
-//	public void testNumber11() throws TransformerException, Docx4JException {
-//	   SwitchTestData data = new SwitchTestData("\\# ", "01");
-//	   doit("MERGEFIELD", data, "01");
-//	   doit("DOCPROPERTY", data, "01");
-//	} 
-//	 
-//	@Test
-//	public void testNumber12() throws TransformerException, Docx4JException {
-//	   SwitchTestData data = new SwitchTestData("\\# ", "0.1");
-//	   doit("MERGEFIELD", data, "0.1");
-//	   doit("DOCPROPERTY", data, "0.1");
-//	} 
-//	 
-//	@Test
-//	public void testNumber13() throws TransformerException, Docx4JException {
-//	   SwitchTestData data = new SwitchTestData("\\# ", "0.0");
-//	   doit("MERGEFIELD", data, "0.0");
-//	   doit("DOCPROPERTY", data, "0.0");
-//	} 
-//	 
-//	@Test
-//	public void testNumber14() throws TransformerException, Docx4JException {
-//	   SwitchTestData data = new SwitchTestData("\\# ", "0.00");
-//	   doit("MERGEFIELD", data, "0.00");
-//	   doit("DOCPROPERTY", data, "0.00");
-//	} 
-//	 
-//	@Test
-//	public void testNumber15() throws TransformerException, Docx4JException {
-//	   SwitchTestData data = new SwitchTestData("\\# ", "0.00 0");
-//	   doit("MERGEFIELD", data, "0.00 0");
-//	   doit("DOCPROPERTY", data, "0.00 0");
-//	} 
-//	 
-//	@Test
-//	public void testNumber16() throws TransformerException, Docx4JException {
-//	   SwitchTestData data = new SwitchTestData("\\# ", "0.00 1");
-//	   doit("MERGEFIELD", data, "0.00 1");
-//	   doit("DOCPROPERTY", data, "0.00 1");
-//	} 
-//	 
-//	@Test
-//	public void testNumber17() throws TransformerException, Docx4JException {
-//	   SwitchTestData data = new SwitchTestData("\\# ", "0.00 A");
-//	   doit("MERGEFIELD", data, "0.00 A");
-//	   doit("DOCPROPERTY", data, "0.00 A");
-//	} 
-//	 
-//	@Test
-//	public void testNumber18() throws TransformerException, Docx4JException {
-//	   SwitchTestData data = new SwitchTestData("\\# ", "0.00 W");
-//	   doit("MERGEFIELD", data, "0.00 W");
-//	   doit("DOCPROPERTY", data, "0.00 W");
-//	} 
-//	 
-//	@Test
-//	public void testNumber19() throws TransformerException, Docx4JException {
-//	   SwitchTestData data = new SwitchTestData("\\# ", "\"01\"");
-//	   doit("MERGEFIELD", data, "01");
-//	   doit("DOCPROPERTY", data, "01");
-//	} 
-//	 
-//	@Test
-//	public void testNumber20() throws TransformerException, Docx4JException {
-//	   SwitchTestData data = new SwitchTestData("\\# ", "\"0.1\"");
-//	   doit("MERGEFIELD", data, "0.1");
-//	   doit("DOCPROPERTY", data, "0.1");
-//	} 
-//	 
-//	@Test
-//	public void testNumber21() throws TransformerException, Docx4JException {
-//	   SwitchTestData data = new SwitchTestData("\\# ", "\"0.0\"");
-//	   doit("MERGEFIELD", data, "0.0");
-//	   doit("DOCPROPERTY", data, "0.0");
-//	} 
-//	 
-//	@Test
-//	public void testNumber22() throws TransformerException, Docx4JException {
-//	   SwitchTestData data = new SwitchTestData("\\# ", "\"0.00\"");
-//	   doit("MERGEFIELD", data, "0.00");
-//	   doit("DOCPROPERTY", data, "0.00");
-//	} 
-//	 
-//	@Test
-//	public void testNumber23() throws TransformerException, Docx4JException {
-//	   SwitchTestData data = new SwitchTestData("\\# ", "\"0.00 0\"");
-//	   doit("MERGEFIELD", data, "0.00 0");
-//	   doit("DOCPROPERTY", data, "0.00 0");
-//	} 
-//	 
-//	@Test
-//	public void testNumber24() throws TransformerException, Docx4JException {
-//	   SwitchTestData data = new SwitchTestData("\\# ", "\"0.00 1\"");
-//	   doit("MERGEFIELD", data, "0.00 1");
-//	   doit("DOCPROPERTY", data, "0.00 1");
-//	} 
-//	 
-//	@Test
-//	public void testNumber25() throws TransformerException, Docx4JException {
-//	   SwitchTestData data = new SwitchTestData("\\# ", "\"0.00 A\"");
-//	   doit("MERGEFIELD", data, "0.00 A");
-//	   doit("DOCPROPERTY", data, "0.00 A");
-//	} 
-//	 
-//	@Test
-//	public void testNumber26() throws TransformerException, Docx4JException {
-//	   SwitchTestData data = new SwitchTestData("\\# ", "\"0.00 W\"");
-//	   doit("MERGEFIELD", data, "0.00 W");
-//	   doit("DOCPROPERTY", data, "0.00 W");
-//	} 
-//	 
-//	@Test
-//	public void testNumber27() throws TransformerException, Docx4JException {
-//	   SwitchTestData data = new SwitchTestData("\\# ", "0000123456");
-//	   doit("MERGEFIELD", data, "0000123456");
-//	   doit("DOCPROPERTY", data, "0000123456");
-//	} 
-//	 
-//	@Test
-//	public void testNumber28() throws TransformerException, Docx4JException {
-//	   SwitchTestData data = new SwitchTestData("\\# ", "000012345.006");
-//	   doit("MERGEFIELD", data, "000012345.006");
-//	   doit("DOCPROPERTY", data, "000012345.006");
-//	} 
-//	 
-//	@Test
-//	public void testNumber29() throws TransformerException, Docx4JException {
-//	   SwitchTestData data = new SwitchTestData("\\# ", "0000123AA456");
-//	   doit("MERGEFIELD", data, "0000123AA456");
-//	   doit("DOCPROPERTY", data, "0000123AA456");
-//	} 
-//	 
-//	@Test
-//	public void testNumber30() throws TransformerException, Docx4JException {
-//	   SwitchTestData data = new SwitchTestData("\\# ", "0000123AA45.006");
-//	   doit("MERGEFIELD", data, "0000123AA45.006");
-//	   doit("DOCPROPERTY", data, "0000123AA45.006");
-//	} 
-	 
-	
-	
+	public void testNumberParsed()throws TransformerException, Docx4JException {
+		SwitchTestData data = new SwitchTestData(format, input);
+		doit("MERGEFIELD", data, result);
+		doit("DOCPROPERTY", data, result);
+	}
+
 	// ---------------------------------------------------------------------------------------
-	
+
 	private void doit(String fieldname, SwitchTestData triple, String expectedResult)  throws TransformerException, Docx4JException {
-		
+
 		String instr = fieldname + " foo " + triple.format;
 		String result = getFormat(instr, triple.val);
 		assertTrue(result.equals(expectedResult));
 	}
-	
+
 	private String getFormat(String instr, String val) throws TransformerException, Docx4JException {
-			
+
 		FldSimpleModel fsm = new FldSimpleModel();
 		fsm.build(instr);
-		return FormattingSwitchHelper.applyFormattingSwitch(null, fsm, val);		
+		return FormattingSwitchHelper.applyFormattingSwitch(null, fsm, val);
 	}
-		
+
 	private static class SwitchTestData {
 
 		String format;
 		String val;
-		
+
 		public String toString() {
 			return "format " + format + " to data " + val;
 		}
@@ -694,6 +145,6 @@ public class FormattingSwitchHelperNumericTests {
 			this.val = val;
 		}
 	}
-	
-	
+
+
 }

--- a/src/test/java/org/docx4j/model/fields/FormattingSwitchHelperNumericTests.java
+++ b/src/test/java/org/docx4j/model/fields/FormattingSwitchHelperNumericTests.java
@@ -17,7 +17,7 @@ import java.util.Collection;
 import java.util.Locale;
 
 @RunWith(value = Parameterized.class)
-public class FormattingSwitchHelperNumericTests {
+public class FormattingSwitchHelperNumericTests extends FormattingTestsBase {
 
 	static Locale initialLocale;
 
@@ -113,38 +113,5 @@ public class FormattingSwitchHelperNumericTests {
 		doit("MERGEFIELD", data, result);
 		doit("DOCPROPERTY", data, result);
 	}
-
-	// ---------------------------------------------------------------------------------------
-
-	private void doit(String fieldname, SwitchTestData triple, String expectedResult)  throws TransformerException, Docx4JException {
-
-		String instr = fieldname + " foo " + triple.format;
-		String result = getFormat(instr, triple.val);
-		assertTrue(result.equals(expectedResult));
-	}
-
-	private String getFormat(String instr, String val) throws TransformerException, Docx4JException {
-
-		FldSimpleModel fsm = new FldSimpleModel();
-		fsm.build(instr);
-		return FormattingSwitchHelper.applyFormattingSwitch(null, fsm, val);
-	}
-
-	private static class SwitchTestData {
-
-		String format;
-		String val;
-
-		public String toString() {
-			return "format " + format + " to data " + val;
-		}
-
-		public SwitchTestData(String format, String val) {
-
-			this.format = format;
-			this.val = val;
-		}
-	}
-
 
 }

--- a/src/test/java/org/docx4j/model/fields/FormattingTestsBase.java
+++ b/src/test/java/org/docx4j/model/fields/FormattingTestsBase.java
@@ -1,0 +1,44 @@
+package org.docx4j.model.fields;
+
+import org.docx4j.openpackaging.exceptions.Docx4JException;
+
+import javax.xml.transform.TransformerException;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Created by enamakonov on 06.11.2017.
+ */
+abstract public class FormattingTestsBase {
+
+	protected void doit(String fieldname, SwitchTestData triple, String expectedResult)  throws TransformerException, Docx4JException {
+
+		String instr = fieldname + " foo " + triple.format;
+		String result = getFormat(instr, triple.val);
+		System.out.println(result);
+		assertTrue(result.equals(expectedResult));
+	}
+
+	private String getFormat(String instr, String val) throws TransformerException, Docx4JException {
+
+		FldSimpleModel fsm = new FldSimpleModel();
+		fsm.build(instr);
+		return FormattingSwitchHelper.applyFormattingSwitch(null, fsm, val);
+	}
+
+	protected static class SwitchTestData {
+
+		String format;
+		String val;
+
+		public String toString() {
+			return "format " + format + " to data " + val;
+		}
+
+		public SwitchTestData(String format, String val) {
+
+            String s = this.format = format;
+            this.val = val;
+		}
+	}
+}


### PR DESCRIPTION
While digging through field updating logic I came across FormattingSwitch...Tests classes which (as I understood) are etalons on how different properties values are parsed. Unfortunately these classes contained a lot of duplicating and were hard to read. So I refactored them:

- Junit's parametrized tests feature was used. So test cases which are only differ in values to test were replaced with single lines in test values list.
- These classes contained duplicating code such as doit, getFormat methods and SwitchTestData utility classes. So FormattingTestsBase superclass was introduced.

As a result, these classes are now several times shorter than originals.