### PR TITLE
Don't warn if Mapper.put is called twice with the same arguments.

### DIFF
--- a/src/main/java/org/docx4j/fonts/Mapper.java
+++ b/src/main/java/org/docx4j/fonts/Mapper.java
@@ -104,7 +104,12 @@ public abstract class Mapper {
 	 * @param pf
 	 */
 	public void put(String key, PhysicalFont pf) {
-		if (fontMappings.get(key.toLowerCase())!=null) {
+		PhysicalFont priorPf = fontMappings.get(key.toLowerCase());
+		if (priorPf != null) {
+			if (priorPf == pf) {
+				// No change, nothing to do.
+				return;
+			}
 			log.warn("Overwriting existing fontMapping: " + key.toLowerCase());
 		}		
 		fontMappings.put(key.toLowerCase(), pf);


### PR DESCRIPTION
There is a warning if a mapping is being overwritten, but if the given
PhysicalFont is identical, there's no change and no need to warn.