### PR TITLE
Implement support for em, rem, and ex as length units in various places.

### DIFF
--- a/src/main/java/org/docx4j/model/properties/paragraph/Indent.java
+++ b/src/main/java/org/docx4j/model/properties/paragraph/Indent.java
@@ -115,13 +115,6 @@ public class Indent extends AbstractParagraphProperty {
 		
 		short type = cssPrimitiveValue.getPrimitiveType();		
 		
-		// TODO
-//		CSSPrimitiveValue.CSS_EMS (Unit 3)
-//		(the 'font-size' of the relevant font)
-//		
-//		CSSPrimitiveValue.CSS_EMX (Unit 4)
-//		(the 'x-height' of the relevant font)		
-		
 		if (CSSPrimitiveValue.CSS_PX == type) {
 			// Unit 5
 			twip = UnitsOfMeasurement.pxToTwip(fVal);
@@ -136,7 +129,13 @@ public class Indent extends AbstractParagraphProperty {
 			twip = UnitsOfMeasurement.inchToTwip(fVal);
 		} else if (CSSPrimitiveValue.CSS_PT == type) {
 			// Unit 9
-			twip = UnitsOfMeasurement.pointToTwip(fVal);	
+			twip = UnitsOfMeasurement.pointToTwip(fVal);
+		} else if (CSSPrimitiveValue.CSS_EMS == type) {
+			// TODO: Don't hardcode 1em == 16px, but make it depend on the paragraph font.
+			twip = UnitsOfMeasurement.pxToTwip(16.0f * fVal);
+		} else if (CSSPrimitiveValue.CSS_EXS == type) {
+			// TODO: Don't hardcode 1ex == 8px, but make it depend on the paragraph font.
+			twip = UnitsOfMeasurement.pxToTwip(8.0f * fVal);
 		} else if (CSSPrimitiveValue.CSS_NUMBER == type) {
 			log.error("Indent: No support for unspecified unit: CSS_NUMBER "); 
 			// http://stackoverflow.com/questions/11479985/what-is-the-default-unit-for-margin-left

--- a/src/main/java/org/docx4j/model/properties/paragraph/LineSpacing.java
+++ b/src/main/java/org/docx4j/model/properties/paragraph/LineSpacing.java
@@ -78,6 +78,19 @@ public class LineSpacing extends AbstractParagraphProperty {
 				log.error("TODO: handle value: " + value.getCssText());
 				return;
 			}
+		} else if (CSSPrimitiveValue.CSS_EMS == type) {
+			// TODO: Use the prevailing font-size, not hardcoded 1em == 16px.
+			twip = UnitsOfMeasurement.pxToTwip(16.0f * fVal);
+		} else if (CSSPrimitiveValue.CSS_EXS == type) {
+			// TODO: Use the prevailing font-size, not hardcoded 1ex == 8px.
+			twip = UnitsOfMeasurement.pxToTwip(8.0f * fVal);
+		} else if (CSSPrimitiveValue.CSS_NUMBER == type) {
+			// This assumes that the number is actually in rem.
+			// This happens because CSSPrimitiveValue does not support rem, and
+			// so the parser just returns it as a number.
+			// TODO: Use the prevailing font-size, not hardcoded 1rem == 16px.
+			// TODO: Can we figure out that rem was actually used?
+			twip = UnitsOfMeasurement.pxToTwip(16.0f * fVal);
 		} else {
 			log.error("No support for unit " + type);
 			// twip = 0;  // don't do that; its a very bad default!

--- a/src/main/java/org/docx4j/model/properties/paragraph/SpaceAfter.java
+++ b/src/main/java/org/docx4j/model/properties/paragraph/SpaceAfter.java
@@ -76,9 +76,11 @@ public class SpaceAfter extends AbstractParagraphProperty {
 		} else if (CSSPrimitiveValue.CSS_PT == type) {
 			twip = UnitsOfMeasurement.pointToTwip(fVal);	
 		} else if (CSSPrimitiveValue.CSS_EMS == type) {
-			log.warn("No support for unit: CSS_EMS; instead of em, please use an absolute unit. ");
-			// calculated based on the font size
-			twip = 0;
+			// TODO: Don't hardcode 1em == 16px, but make it depend on the paragraph font.
+			twip = UnitsOfMeasurement.pxToTwip(16.0f * fVal);
+		} else if (CSSPrimitiveValue.CSS_EXS == type) {
+			// TODO: Don't hardcode 1ex == 8px, but make it depend on the paragraph font.
+			twip = UnitsOfMeasurement.pxToTwip(8.0f * fVal);
 		} else if (CSSPrimitiveValue.CSS_PX == type) {
 			twip = UnitsOfMeasurement.pxToTwip(fVal);
 		} else if (CSSPrimitiveValue.CSS_NUMBER == type) {

--- a/src/main/java/org/docx4j/model/properties/run/FontSize.java
+++ b/src/main/java/org/docx4j/model/properties/run/FontSize.java
@@ -107,6 +107,14 @@ public class FontSize extends AbstractRunProperty {
 		    hpsMeasure.setVal(BigInteger.valueOf(iVal));
 		    this.setObject(hpsMeasure);
 		    
+		} else if (cssPrimitiveValue.getPrimitiveType()!=CSSPrimitiveValue.CSS_EMS) {
+			// TODO: Use the size of the font on the parent element rather than assuming 1em == medium.
+			float emVal = cssPrimitiveValue.getFloatValue(CSSPrimitiveValue.CSS_EMS);
+			hpsMeasure.setVal( BigInteger.valueOf( Math.round(emVal * mediumHP) ));
+		} else if (cssPrimitiveValue.getPrimitiveType()!=CSSPrimitiveValue.CSS_EXS) {
+			// TODO: Use the size of the font on the parent element rather than assuming 1ex == 0.5 * medium.
+			float exVal = cssPrimitiveValue.getFloatValue(CSSPrimitiveValue.CSS_EXS);
+			hpsMeasure.setVal( BigInteger.valueOf( Math.round(0.5 * exVal * mediumHP) ));
 		} else  if (cssPrimitiveValue.getPrimitiveType()!=CSSPrimitiveValue.CSS_PT) {
 			
 			log.error("TODO FontSize Handle units: " + cssPrimitiveValue.getPrimitiveType() );

--- a/src/main/java/org/docx4j/model/properties/table/Indent.java
+++ b/src/main/java/org/docx4j/model/properties/table/Indent.java
@@ -65,7 +65,13 @@ public class Indent extends AbstractTableProperty {
 		if (CSSPrimitiveValue.CSS_IN == type) {
 			twip = UnitsOfMeasurement.inchToTwip(fVal);
 		} else if (CSSPrimitiveValue.CSS_MM == type) {
-			twip = UnitsOfMeasurement.mmToTwip(fVal);		
+			twip = UnitsOfMeasurement.mmToTwip(fVal);
+		} else if (CSSPrimitiveValue.CSS_EMS == type) {
+			// TODO: Don't hardcode 1em == 16px, but make it depend on the paragraph font.
+			twip = UnitsOfMeasurement.pxToTwip(16.0f * fVal);
+		} else if (CSSPrimitiveValue.CSS_EXS == type) {
+			// TODO: Don't hardcode 1ex == 8px, but make it depend on the paragraph font.
+			twip = UnitsOfMeasurement.pxToTwip(8.0f * fVal);
 		} else {
 			log.error("No support for unit " + type);
 			twip = 0;


### PR DESCRIPTION
This uses 1rem == 1em == 16px or 1em == medium, and 1ex == 0.5em.
This isn't right, but it's better than nothing.

This also is pretty hacky in that it treats a parsed CSS_NUMBER as a rem.
This is because Flying Saucer is based around CSS2, which doesn't include rem,
so it returns them as plain numbers instead.