### PR TITLE
RGB to hex boundary condition fix in UnitsOfMeasurement

### DIFF
--- a/src/main/java/org/docx4j/UnitsOfMeasurement.java
+++ b/src/main/java/org/docx4j/UnitsOfMeasurement.java
@@ -143,13 +143,13 @@ public class UnitsOfMeasurement {
 	private static String getHex(float f) {
 		
 		int i = Math.round(f);
+		String hexValue = Integer.toHexString(i);
 		
-		if (i<=16) {
+		if (i < 16) {
 			// Pad so we have 2 digits
-			return "0" + Integer.toHexString( i );
-		} else {
-			return Integer.toHexString( i );
+			return "0" + hexValue;
 		}
+		return hexValue;
 	}
 
 	/**


### PR DESCRIPTION
The getHex(float) function works incorrectly with the boundary value. An attempt to convert one of the RBG color components whose value is 16 results in "010", rather then just "10". (e.g. {background-color: rgb(201, 16, 76);})