### PR TITLE
refactor diffWorker method and prevent it from throwing NPE

### DIFF
--- a/src/main/java/org/docx4j/diff/Differencer.java
+++ b/src/main/java/org/docx4j/diff/Differencer.java
@@ -49,6 +49,7 @@ import javax.xml.transform.Templates;
 import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.stream.StreamSource;
 
+import org.apache.commons.io.IOUtils;
 import org.docx4j.XmlUtils;
 import org.docx4j.jaxb.Context;
 import org.docx4j.openpackaging.parts.Part;
@@ -324,15 +325,13 @@ public class Differencer {
 			Docx4jDriver.diff(newer,
 					   older,
 					   diffxResult);
-				// The signature which takes Reader objects appears to be broken
-			diffxResult.close();
+			toWML( diffxResult.toString(),  result, author, date,
+				docPartRelsNewer,  docPartRelsOlder);
 		} catch (Exception exc) {
-			exc.printStackTrace();
-			diffxResult = null;
+			throw new RuntimeException("Docx4jDriver.diff failed.", exc);
+		} finally {
+			IOUtils.closeQuietly(diffxResult);
 		}
-
-		toWML( diffxResult.toString(),  result, author, date,
-				 docPartRelsNewer,  docPartRelsOlder);
 	}
 	
 	public  void toWML(String in, javax.xml.transform.Result result, String author, java.util.Calendar date,

--- a/src/main/java/org/docx4j/diff/Differencer.java
+++ b/src/main/java/org/docx4j/diff/Differencer.java
@@ -328,7 +328,7 @@ public class Differencer {
 			toWML( diffxResult.toString(),  result, author, date,
 				docPartRelsNewer,  docPartRelsOlder);
 		} catch (Exception exc) {
-			throw new RuntimeException("Docx4jDriver.diff failed.", exc);
+			throw new RuntimeException("diffWorker failed.", exc);
 		} finally {
 			IOUtils.closeQuietly(diffxResult);
 		}


### PR DESCRIPTION
In case of some errors diffxResult is set to null in line `331`, and than the `NullPointerException` is thrown in line `334` (`diffxResult.toString()`).
 Now custom `RuntimeException` will be thrown in this case, which seems clearer.
Moreover it is usually strongly recomended to close `Closable` resouces in `finally` block.