### PR TITLE
Issue 320 No auto-format

### DIFF
--- a/src/docx4j-extras/jcr/org/docx4j/openpackaging/io/SaveToJCR.java
+++ b/src/docx4j-extras/jcr/org/docx4j/openpackaging/io/SaveToJCR.java
@@ -732,10 +732,8 @@ public class SaveToJCR {
 			
 			Version firstVersion = cmContentNode.checkin();
 		} catch (Exception e ) {
-			log.error(e);
 			throw new Docx4JException("Failed to put binary part", e);			
 		} finally {
-			
 			try {
 				log.debug("closing binary input stream");
 				bin.close();

--- a/src/main/java/org/docx4j/Docx4J.java
+++ b/src/main/java/org/docx4j/Docx4J.java
@@ -27,7 +27,6 @@ import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -57,26 +56,20 @@ import org.docx4j.model.datastorage.OpenDoPEIntegrityAfterBinding;
 import org.docx4j.model.datastorage.RemovalHandler;
 import org.docx4j.model.datastorage.XsltFinisher;
 import org.docx4j.model.datastorage.XsltProvider;
-import org.docx4j.model.datastorage.XsltProviderImpl;
 import org.docx4j.openpackaging.exceptions.Docx4JException;
-import org.docx4j.openpackaging.io.SaveToZipFile;
 import org.docx4j.openpackaging.io3.Load3;
 import org.docx4j.openpackaging.io3.stores.ZipPartStore;
 import org.docx4j.openpackaging.packages.Filetype;
 import org.docx4j.openpackaging.packages.OpcPackage;
 import org.docx4j.openpackaging.packages.WordprocessingMLPackage;
-import org.docx4j.openpackaging.parts.CustomXmlDataStoragePart;
 import org.docx4j.openpackaging.parts.CustomXmlPart;
 import org.docx4j.openpackaging.parts.Part;
 import org.docx4j.openpackaging.parts.PartName;
-import org.docx4j.openpackaging.parts.WordprocessingML.FooterPart;
-import org.docx4j.openpackaging.parts.WordprocessingML.HeaderPart;
 import org.docx4j.openpackaging.parts.opendope.ConditionsPart;
 import org.docx4j.openpackaging.parts.opendope.XPathsPart;
 import org.docx4j.openpackaging.parts.relationships.Namespaces;
 import org.docx4j.openpackaging.parts.relationships.RelationshipsPart;
 import org.docx4j.relationships.Relationship;
-import org.docx4j.services.client.ConversionException;
 import org.docx4j.services.client.Converter;
 import org.docx4j.services.client.ConverterHttp;
 import org.docx4j.services.client.Format;
@@ -794,8 +787,7 @@ public class Docx4J {
 			return (Exporter<FOSettings>)method.invoke(null, null);
 			
 		} catch (Exception e) {
-			log.info("org.docx4j.convert.out.fo.FOExporterVisitor not found; if you want it, add docx4j-export-FO to your path.  Doing so will disable Plutext's PDF Converter." + "/n" + e.getMessage());
-			throw new Docx4JException(e.getMessage(), e);
+			throw new Docx4JException("org.docx4j.convert.out.fo.FOExporterVisitor not found; if you want it, add docx4j-export-FO to your path.  Doing so will disable Plutext's PDF Converter." + "/n" + e.getMessage(), e);
 		}			
 	}
 
@@ -810,8 +802,7 @@ public class Docx4J {
 			return (Exporter<FOSettings>)method.invoke(null, null);
 			
 		} catch (Exception e) {
-			log.info("org.docx4j.convert.out.fo.FOExporterXslt not found; if you want it, add docx4j-export-FO to your path.  " + "/n" + e.getMessage());
-			throw new Docx4JException(e.getMessage(), e);
+			throw new Docx4JException("org.docx4j.convert.out.fo.FOExporterXslt not found; if you want it, add docx4j-export-FO to your path.  " + "/n" + e.getMessage(), e);
 		}			
 		
 	}

--- a/src/main/java/org/docx4j/XmlUtils.java
+++ b/src/main/java/org/docx4j/XmlUtils.java
@@ -41,7 +41,6 @@ import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
 import javax.xml.bind.UnmarshalException;
 import javax.xml.bind.Unmarshaller;
-import javax.xml.bind.ValidationEventHandler;
 import javax.xml.bind.util.JAXBResult;
 import javax.xml.bind.util.JAXBSource;
 import javax.xml.crypto.dsig.CanonicalizationMethod;
@@ -66,10 +65,8 @@ import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpressionException;
 
-import org.apache.commons.io.IOUtils;
 import org.docx4j.jaxb.Context;
 import org.docx4j.jaxb.JAXBAssociation;
-import org.docx4j.jaxb.JAXBImplementation;
 import org.docx4j.jaxb.JaxbValidationEventHandler;
 import org.docx4j.jaxb.McIgnorableNamespaceDeclarator;
 import org.docx4j.jaxb.NamespacePrefixMapperUtils;
@@ -1511,8 +1508,7 @@ public class XmlUtils {
             }
             return result;
         } catch (XPathExpressionException e) {
-			log.error("Problem with '" + xpathExpression + "'", e);
-            throw new RuntimeException(e);
+            throw new RuntimeException("Problem with '" + xpathExpression + "'",e);
         }
     }	
 

--- a/src/main/java/org/docx4j/convert/out/common/AbstractExporter.java
+++ b/src/main/java/org/docx4j/convert/out/common/AbstractExporter.java
@@ -19,7 +19,6 @@
  */
 package org.docx4j.convert.out.common;
 
-import java.io.IOException;
 import java.io.OutputStream;
 
 import org.docx4j.convert.out.AbstractConversionSettings;
@@ -96,7 +95,6 @@ public abstract class AbstractExporter<CS extends AbstractConversionSettings, CC
 			logDebugStep(log, "Conversion done", startTime);
 			
 //		} catch (Docx4JException e) {
-//			log.error(e.getMessage(), e);
 //			throw e;
 		} catch (IllegalArgumentException e) {
 			if (e.getMessage().contains("Only non-null Positions with an index can be checked")) {
@@ -105,7 +103,6 @@ public abstract class AbstractExporter<CS extends AbstractConversionSettings, CC
 				throw new Docx4JException("Exception exporting package", e);
 			}
 		} catch (Exception e) {
-			log.error("Exception exporting package", e);
 			throw new Docx4JException("Exception exporting package", e);
 		} 
 	}

--- a/src/main/java/org/docx4j/convert/out/html/SdtToListSdtTagHandler.java
+++ b/src/main/java/org/docx4j/convert/out/html/SdtToListSdtTagHandler.java
@@ -46,12 +46,9 @@ public class SdtToListSdtTagHandler extends SdtTagHandler {
 				docfrag.appendChild(xhtmlDiv);						
     			return attachContents(docfrag, xhtmlDiv, childResults);
 			}
-			
 		} catch (Exception e) {
-			log.error(e.getMessage(), e);
 			throw new TransformerException(e);
 		}
-
 	}
 	
 
@@ -81,12 +78,8 @@ public class SdtToListSdtTagHandler extends SdtTagHandler {
 				docfrag.appendChild(xhtmlDiv);						
     			return attachContents(docfrag, xhtmlDiv, resultSoFar);
 			}
-			
 		} catch (Exception e) {
-			log.error(e.getMessage(), e);
 			throw new TransformerException(e);
 		}
 	}
-	
-	    	
 }

--- a/src/main/java/org/docx4j/convert/out/html/TagClass.java
+++ b/src/main/java/org/docx4j/convert/out/html/TagClass.java
@@ -133,7 +133,6 @@ public class TagClass extends SdtTagHandler {
 			return attachContents(docfrag, xhtmlDiv, childResults);
 			
 		} catch (Exception e) {
-			log.error(e.getMessage(), e);
 			throw new TransformerException(e);
 		}
 
@@ -153,11 +152,7 @@ public class TagClass extends SdtTagHandler {
 				return attachContents(docfrag, xhtmlDiv, resultSoFar);
 				
 			} catch (Exception e) {
-				log.error(e.getMessage(), e);
 				throw new TransformerException(e);
 			}
 		}
-		
-	
-
 }

--- a/src/main/java/org/docx4j/convert/out/html/TagSingleBox.java
+++ b/src/main/java/org/docx4j/convert/out/html/TagSingleBox.java
@@ -119,7 +119,6 @@ public class TagSingleBox extends SdtTagHandler {
 			return attachContents(docfrag, xhtmlDiv, contents);
 			
 		} catch (Exception e) {
-			log.error(e.getMessage(), e);
 			throw new TransformerException(e);
 		}
 
@@ -146,7 +145,6 @@ public class TagSingleBox extends SdtTagHandler {
 				return attachContents(docfrag, xhtmlDiv, contents);
 				
 			} catch (Exception e) {
-				log.error(e.getMessage(), e);
 				throw new TransformerException(e);
 			}
 		}

--- a/src/main/java/org/docx4j/diff/Differencer.java
+++ b/src/main/java/org/docx4j/diff/Differencer.java
@@ -1327,8 +1327,7 @@ spacing<ins> properly I would</ins> <ins>say.</ins><del>property.</del></w:t></w
 									reader.getNamespaceURI(i) );
 						}
 					} catch (XMLStreamException e) {
-						log.error("Issue at element: " + reader.getLocalName() + "\n", e);
-						throw e;
+						throw new XMLStreamException("Issue at element: " + reader.getLocalName() + "\n",e);
 					}
                     
                     break;

--- a/src/main/java/org/docx4j/model/datastorage/BindingTraverserXSLT.java
+++ b/src/main/java/org/docx4j/model/datastorage/BindingTraverserXSLT.java
@@ -38,8 +38,8 @@ import org.docx4j.jaxb.Context;
 import org.docx4j.jaxb.JaxbValidationEventHandler;
 import org.docx4j.model.sdt.QueryString;
 import org.docx4j.model.styles.StyleTree;
-import org.docx4j.model.styles.StyleUtil;
 import org.docx4j.model.styles.StyleTree.AugmentedStyle;
+import org.docx4j.model.styles.StyleUtil;
 import org.docx4j.model.styles.Tree;
 import org.docx4j.openpackaging.exceptions.Docx4JException;
 import org.docx4j.openpackaging.exceptions.InvalidFormatException;
@@ -937,8 +937,7 @@ public class BindingTraverserXSLT extends BindingTraverserCommonImpl {
 			xpath = xpathsMap.get(xpathId);
 
 		} catch (InputIntegrityException iie) {
-			log.error("Couldn't find xpath with id: " + xpathId + " referenced from part " + sourcePart.getPartName().getName() + " at " + odTag);
-			throw iie;
+			throw new InputIntegrityException("Couldn't find xpath with id: " + xpathId + " referenced from part " + sourcePart.getPartName().getName() + " at " + odTag,iie);
 			
 			// Could fallback to trying to use the databinding sdtPr, but would need to pass that in
 		}

--- a/src/main/java/org/docx4j/model/datastorage/InputIntegrityException.java
+++ b/src/main/java/org/docx4j/model/datastorage/InputIntegrityException.java
@@ -6,9 +6,9 @@ public class InputIntegrityException extends RuntimeException {
 		super(msg);
 	}
 	
-//	public InputIntegrityException(String msg, Exception e) {
-//		super(msg, e);
-//	}
+	public InputIntegrityException(String msg, Exception e) {
+		super(msg, e);
+	}
 
 //	public InputIntegrityException(String msg, Throwable t) {
 //		super(msg, t);

--- a/src/main/java/org/docx4j/model/fields/FormattingSwitchHelper.java
+++ b/src/main/java/org/docx4j/model/fields/FormattingSwitchHelper.java
@@ -12,12 +12,12 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.docx4j.openpackaging.exceptions.Docx4JException;
 import org.docx4j.openpackaging.packages.WordprocessingMLPackage;
 import org.docx4j.openpackaging.parts.WordprocessingML.DocumentSettingsPart;
 import org.docx4j.wml.NumberFormat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Formats the string value of the field according to the three possible formatting switches:
@@ -209,6 +209,9 @@ public class FormattingSwitchHelper {
 		public FieldResultIsNotADateOrTimeException(String string) {
 			super(string);
 		}
+		public FieldResultIsNotADateOrTimeException(String string,Exception cause) {
+			super(string,cause);
+		}
 	}
 	
 	private static class FieldResultIsNotANumberException extends Exception {
@@ -366,8 +369,7 @@ public class FormattingSwitchHelper {
 				
 				return (Date)dateTimeFormat.parse(dateStr);
 			} catch (ParseException e) {
-				log.warn("Can't parse " + dateStr + " using format " + inputFormat);				
-				throw new FieldResultIsNotADateOrTimeException();
+				throw new FieldResultIsNotADateOrTimeException("Can't parse " + dateStr + " using format " + inputFormat,e);
 			}
 		}
 	}

--- a/src/main/java/org/docx4j/openpackaging/contenttype/ContentTypeManager.java
+++ b/src/main/java/org/docx4j/openpackaging/contenttype/ContentTypeManager.java
@@ -51,7 +51,6 @@ package org.docx4j.openpackaging.contenttype;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.lang.reflect.Constructor;
-import java.lang.reflect.Method;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Iterator;
@@ -71,10 +70,10 @@ import org.docx4j.jaxb.NamespacePrefixMapperUtils;
 import org.docx4j.openpackaging.exceptions.Docx4JException;
 import org.docx4j.openpackaging.exceptions.InvalidFormatException;
 import org.docx4j.openpackaging.exceptions.PartUnrecognisedException;
+import org.docx4j.openpackaging.packages.DefaultPackage;
 import org.docx4j.openpackaging.packages.OpcPackage;
 import org.docx4j.openpackaging.packages.PresentationMLPackage;
 import org.docx4j.openpackaging.packages.SpreadsheetMLPackage;
-import org.docx4j.openpackaging.packages.DefaultPackage;
 import org.docx4j.openpackaging.packages.WordprocessingMLPackage;
 import org.docx4j.openpackaging.packages.WordprocessingMLTemplatePackage;
 import org.docx4j.openpackaging.parts.CustomXmlDataStoragePropertiesPart;
@@ -845,7 +844,6 @@ public class ContentTypeManager  {
 			}
 			
 		} catch (Exception e ) {
-			log.error(e.getMessage(), e);
 			throw new InvalidFormatException("Bad [Content_Types].xml", e);
 		}
 		

--- a/src/main/java/org/docx4j/openpackaging/io/LoadFromZipNG.java
+++ b/src/main/java/org/docx4j/openpackaging/io/LoadFromZipNG.java
@@ -188,7 +188,6 @@ public class LoadFromZipNG extends Load {
             }
             zis.close();
         } catch (Exception e) {
-            log.error(e.getMessage());
             throw new Docx4JException("Error processing zip file (is it a zip file?)", e);
         }	
 	            
@@ -270,9 +269,7 @@ public class LoadFromZipNG extends Load {
 			rp.unmarshal(is);
 			
 		} catch (Exception e) {
-			log.error(e.getMessage(), e);
 			throw new Docx4JException("Error getting document from Zipped Part: _rels/.rels " , e);
-			
 		} finally {
 			IOUtils.closeQuietly(is);
 		}

--- a/src/main/java/org/docx4j/openpackaging/io3/Load3.java
+++ b/src/main/java/org/docx4j/openpackaging/io3/Load3.java
@@ -220,7 +220,6 @@ public class Load3 extends Load {
 			rp.unmarshal(is);
 			
 		} catch (Exception e) {
-			log.error(e.getMessage(), e);
 			throw new Docx4JException("Error getting document from Zipped Part: _rels/.rels " , e);
 			
 		} finally {

--- a/src/main/java/org/docx4j/openpackaging/io3/stores/ZipPartStore.java
+++ b/src/main/java/org/docx4j/openpackaging/io3/stores/ZipPartStore.java
@@ -36,11 +36,11 @@ import java.util.zip.CRC32;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
+import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
 import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream;
 import org.apache.commons.compress.archivers.zip.ZipArchiveOutputStream;
 import org.apache.commons.compress.archivers.zip.ZipFile;
-import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.io.IOUtils;
 import org.docx4j.Docx4jProperties;
 import org.docx4j.XmlUtils;
@@ -113,7 +113,6 @@ public class ZipPartStore implements PartStore {
 			} catch (PartTooLargeException e) {
 				throw e;
 			} catch (Exception e) {
-	            log.error(e.getMessage());
 	            throw new Docx4JException("Error processing zip file (is it a zip file?)", e);
 			}
 		}
@@ -159,10 +158,8 @@ public class ZipPartStore implements PartStore {
 		} catch (PartTooLargeException e) {
 			throw e;
         } catch (Exception e) {
-            log.error(e.getMessage());
             throw new Docx4JException("Error processing zip file (is it a zip file?)", e);
         }
-
 	}
 
 	private PartStore sourcePartStore;

--- a/src/main/java/org/docx4j/openpackaging/packages/OpcPackage.java
+++ b/src/main/java/org/docx4j/openpackaging/packages/OpcPackage.java
@@ -214,6 +214,7 @@ public abstract class OpcPackage extends Base implements PackageIdentifier {
 		}
 	}
 	
+	@Override
 	public OpcPackage getPackage() {
 		return this;
 	}
@@ -281,7 +282,16 @@ public abstract class OpcPackage extends Base implements PackageIdentifier {
 		PackageIdentifier name = new PackageIdentifierTransient(docxFile.getName());
 		
 		try {
-			return OpcPackage.load(name, new FileInputStream(docxFile), password );
+			 final FileInputStream fileInputStream = new FileInputStream(docxFile);
+			    try {
+				return OpcPackage.load(name, fileInputStream, password);
+			    } finally {
+				try {
+				    fileInputStream.close();
+				} catch (final IOException e) {
+				    log.warn("Could not close fileInputStream of file {}: {}", docxFile.toString(), e.getMessage());
+				}
+			    }
 		} catch (final FileNotFoundException e) {
 			throw new Docx4JException("Couldn't load file from " + docxFile.getAbsolutePath(), e);
 		}
@@ -302,7 +312,16 @@ public abstract class OpcPackage extends Base implements PackageIdentifier {
 	public static OpcPackage load(PackageIdentifier pkgIdentifier, final java.io.File docxFile, String password) throws Docx4JException {
 		
 		try {
-			return OpcPackage.load(pkgIdentifier, new FileInputStream(docxFile), password );
+			final FileInputStream fileInputStream = new FileInputStream(docxFile);
+			try {
+				return OpcPackage.load(pkgIdentifier, fileInputStream, password);
+			} finally {
+				try {
+					fileInputStream.close();
+				} catch (final IOException e) {
+					log.warn("Could not close fileInputStream of file {}: {}", docxFile.toString(), e.getMessage());
+				}
+			}
 		} catch (final FileNotFoundException e) {
 			throw new Docx4JException("Couldn't load file from " + docxFile.getAbsolutePath(), e);
 		}
@@ -496,11 +515,18 @@ public abstract class OpcPackage extends Base implements PackageIdentifier {
 			return opcPackage;
 			
 		} else {
-			try {			
-				return load(pkgIdentifier,
-						new FileInputStream(file),
-						type,
-						password);
+			try {
+
+				final FileInputStream fileInputStream = new FileInputStream(file);
+				try {
+					return load(pkgIdentifier, fileInputStream, type, password);
+				} finally {
+					try {
+						fileInputStream.close();
+					} catch (final IOException e) {
+						log.warn("Could not close fileInputStream of file {}: {}", file.toString(), e.getMessage());
+					}
+				}
 			} catch (final FileNotFoundException e) {
 				throw new Docx4JException("Couldn't load file from " + file.getAbsolutePath(), e);
 			}
@@ -911,6 +937,7 @@ public abstract class OpcPackage extends Base implements PackageIdentifier {
 	
 
 	/** @since 2.7.2 */
+	@Override
 	public OpcPackage clone() {
 		
 		OpcPackage result = null;
@@ -983,6 +1010,7 @@ public abstract class OpcPackage extends Base implements PackageIdentifier {
 	 * Reinit fields so this pkg object can be re-used.
 	 * @since 3.3.7
 	 */
+	@Override
 	public void reset() {
 		super.reset();
 		handled = new HashMap<String, String>();

--- a/src/main/java/org/docx4j/openpackaging/packages/OpcPackage.java
+++ b/src/main/java/org/docx4j/openpackaging/packages/OpcPackage.java
@@ -55,11 +55,9 @@ import org.docx4j.jaxb.Context;
 import org.docx4j.jaxb.NamespacePrefixMapperUtils;
 import org.docx4j.openpackaging.Base;
 import org.docx4j.openpackaging.PackageRelsUtil;
-import org.docx4j.openpackaging.contenttype.ContentType;
 import org.docx4j.openpackaging.contenttype.ContentTypeManager;
 import org.docx4j.openpackaging.exceptions.Docx4JException;
 import org.docx4j.openpackaging.exceptions.InvalidFormatException;
-import org.docx4j.openpackaging.io.LoadFromZipNG;
 import org.docx4j.openpackaging.io.SaveToZipFile;
 import org.docx4j.openpackaging.io3.Load3;
 import org.docx4j.openpackaging.io3.Save;
@@ -285,7 +283,6 @@ public abstract class OpcPackage extends Base implements PackageIdentifier {
 		try {
 			return OpcPackage.load(name, new FileInputStream(docxFile), password );
 		} catch (final FileNotFoundException e) {
-			OpcPackage.log.error(e.getMessage(), e);
 			throw new Docx4JException("Couldn't load file from " + docxFile.getAbsolutePath(), e);
 		}
 	}
@@ -307,7 +304,6 @@ public abstract class OpcPackage extends Base implements PackageIdentifier {
 		try {
 			return OpcPackage.load(pkgIdentifier, new FileInputStream(docxFile), password );
 		} catch (final FileNotFoundException e) {
-			OpcPackage.log.error(e.getMessage(), e);
 			throw new Docx4JException("Couldn't load file from " + docxFile.getAbsolutePath(), e);
 		}
 	}

--- a/src/main/java/org/docx4j/openpackaging/parts/JaxbXmlPart.java
+++ b/src/main/java/org/docx4j/openpackaging/parts/JaxbXmlPart.java
@@ -50,7 +50,6 @@ import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 import javax.xml.stream.XMLStreamWriter;
 import javax.xml.transform.Result;
-import javax.xml.transform.Source;
 import javax.xml.transform.Templates;
 import javax.xml.transform.stream.StreamSource;
 
@@ -199,8 +198,7 @@ public abstract class JaxbXmlPart<E> /* used directly only by DocProps parts, Re
 					unmarshal( is );
 				}
 			} catch (JAXBException e) {
-				log.error("Problem with part " + this.getPartName());
-				throw new Docx4JException(e.getMessage(), e);
+				throw new Docx4JException("Problem with part " + this.getPartName(), e);
 //			} catch (Docx4JException e) {
 //				log.error(e.getMessage(), e);
 			} finally {
@@ -721,12 +719,8 @@ public abstract class JaxbXmlPart<E> /* used directly only by DocProps parts, Re
 			((McIgnorableNamespaceDeclarator) namespacePrefixMapper).setMcIgnorable(null);
 			
 		} catch (Docx4JException e) {
-			log.error(e.getMessage(), e);
 			throw new JAXBException(e);  // avoid change to method signature
-		} catch (JAXBException e) {
-			log.error(e.getMessage(), e);
-			throw e;
-		}
+		} 
 	}
     
     /**
@@ -924,13 +918,8 @@ public abstract class JaxbXmlPart<E> /* used directly only by DocProps parts, Re
 	    	
 
 		} catch (Docx4JException e) {
-			log.error(e.getMessage(), e);
 			throw new JAXBException(e);  // avoid change to method signature
-		} catch (JAXBException e) {
-			log.error(e.getMessage(), e);
-			throw e;
 		} catch (Exception e) {
-			log.error(e.getMessage(), e);
 			throw new JAXBException(e);  // avoid change to method signature
 		}
 	}
@@ -1070,7 +1059,6 @@ public abstract class JaxbXmlPart<E> /* used directly only by DocProps parts, Re
 							at com.sun.org.apache.xerces.internal.impl.XMLStreamReaderImpl.next(Unknown Source)
 							at com.sun.xml.internal.bind.v2.runtime.unmarshaller.StAXStreamConnector.bridge(Unknown Source)
 						 */
-					log.error(ue.getMessage(), ue);
 					throw ue;
 				}
 				
@@ -1094,15 +1082,12 @@ public abstract class JaxbXmlPart<E> /* used directly only by DocProps parts, Re
 					}
 											
 				} else {
-					log.error(ue.getMessage(), ue);
-					log.error(".. and mark not supported");
-					throw ue;
+					throw new UnmarshalException("Mark not supported",ue);
 				}
 			}
 			
 
 		} catch (XMLStreamException e1) {
-			log.error(e1.getMessage(), e1);
 			throw new JAXBException(e1);
 		}
 		return jaxbElement;

--- a/src/main/java/org/docx4j/openpackaging/parts/JaxbXmlPartXPathAware.java
+++ b/src/main/java/org/docx4j/openpackaging/parts/JaxbXmlPartXPathAware.java
@@ -21,15 +21,12 @@ package org.docx4j.openpackaging.parts;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import javax.xml.bind.Binder;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.UnmarshalException;
 import javax.xml.bind.Unmarshaller;
-import javax.xml.bind.util.JAXBResult;
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamReader;
@@ -713,7 +710,6 @@ implements XPathEnabled<E> {
 			return jaxbElement;
 			
 		} catch (JAXBException e) {
-			log.error(e.getMessage(), e);
 			throw e;
 		}
 	}

--- a/src/main/java/org/docx4j/openpackaging/parts/PartName.java
+++ b/src/main/java/org/docx4j/openpackaging/parts/PartName.java
@@ -153,7 +153,6 @@ public final class PartName implements Comparable<PartName> {
 		try {
 			partURI = new URI(partName);
 		} catch (URISyntaxException e) {
-			log.error( e.getMessage() );
 			throw new IllegalArgumentException(
 					"partName argmument is not a valid OPC part name !");
 		}

--- a/src/main/java/org/docx4j/openpackaging/parts/relationships/RelationshipsPart.java
+++ b/src/main/java/org/docx4j/openpackaging/parts/relationships/RelationshipsPart.java
@@ -167,7 +167,6 @@ public final class RelationshipsPart extends JaxbXmlPart<Relationships> {
 				return new PartName(PartName.getRelationshipsPartName(
 						sourceP.getPartName().getName() ));
 			} catch (InvalidFormatException e) {
-				log.error(e.getMessage(), e);
 				throw new RuntimeException(e);
 			}
 		} else {

--- a/src/main/java/org/docx4j/org/apache/xml/serializer/CharInfo.java
+++ b/src/main/java/org/docx4j/org/apache/xml/serializer/CharInfo.java
@@ -24,14 +24,11 @@ import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
-import java.net.URL;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.Hashtable;
-import java.util.PropertyResourceBundle;
-import java.util.ResourceBundle;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+import java.util.HashMap;
+import java.util.Hashtable;
+import java.util.ResourceBundle;
 
 import javax.xml.transform.TransformerException;
 
@@ -525,7 +522,6 @@ final class CharInfo
                 absoluteEntitiesFileName =
                     SystemIDResolver.getAbsoluteURI(entitiesFileName, null);
             } catch (TransformerException te) {
-            	log.error(te.getMessage(), te);
                 throw new WrappedRuntimeException(te);
             }
         }

--- a/src/main/java/org/docx4j/services/client/ConverterHttp.java
+++ b/src/main/java/org/docx4j/services/client/ConverterHttp.java
@@ -227,12 +227,10 @@ public class ConverterHttp implements Converter {
 							+ response);
 			}
 		} catch (java.net.UnknownHostException uhe) {
-    		log.error("\nLooks like you have the wrong host in your endpoint URL '" + URL + "'\n");
-			throw new ConversionException(uhe.getMessage(), uhe);		    
-
+			throw new ConversionException("\nLooks like you have the wrong host in your endpoint URL '" + URL + "'\n", uhe);		    
 		} catch (java.net.SocketException se) {
 			
-			log.error(se.getMessage());
+			String errorMessage="";
 			
 			if (System.getProperty("os.name").toUpperCase().indexOf("WINDOWS") > -1) {
 				// In some circumstances, the converter will return an error before waiting for
@@ -241,16 +239,13 @@ public class ConverterHttp implements Converter {
 				// whereas on Linux and OSX, the SocketException still occurs, but the response is read
 				// (though possibly only sometimes/partially, since the socket exception occurs
 				// in BasicHttpEntity.writeTo)
-				log.error("This behaviour may be Windows client OS specific; please look in the server logs or try a Linux client");
-				// Try to ensure user sees this, even if they don't have logging configured!
-				System.err.println("This behaviour may be Windows client OS specific; please look in the server logs or try a Linux client");
+				errorMessage="This behaviour may be Windows client OS specific; please look in the server logs or try a Linux client";
 			}
 			
 			// TODO: What happens on Android? 
-			throw new ConversionException(se.getMessage(), se);		    
+			throw new ConversionException(errorMessage, se);		    
 
 		} catch (IOException ioe) {
-			ioe.printStackTrace();
 			throw new ConversionException(ioe.getMessage(), ioe);		    
 		} finally {
 		    try {

--- a/src/pptx4j/java/org/docx4j/openpackaging/parts/PresentationML/SlidePart.java
+++ b/src/pptx4j/java/org/docx4j/openpackaging/parts/PresentationML/SlidePart.java
@@ -20,17 +20,9 @@
 
 package org.docx4j.openpackaging.parts.PresentationML;
 
-import java.io.IOException;
-
 import javax.xml.bind.JAXBException;
-import javax.xml.bind.UnmarshalException;
-import javax.xml.bind.Unmarshaller;
-import javax.xml.transform.Templates;
-import javax.xml.transform.dom.DOMResult;
 
-import org.apache.commons.io.IOUtils;
 import org.docx4j.XmlUtils;
-import org.docx4j.jaxb.JaxbValidationEventHandler;
 import org.docx4j.jaxb.McIgnorableNamespaceDeclarator;
 import org.docx4j.openpackaging.exceptions.InvalidFormatException;
 import org.docx4j.openpackaging.parts.Part;
@@ -312,7 +304,6 @@ public final class SlidePart extends JaxbPmlPart<Sld> {
 //			return jaxbElement;
 //			
 //		} catch (JAXBException e) {
-//			log.error(e.getMessage(), e);
 //			throw e;
 //		}
 //	}	


### PR DESCRIPTION
I disabled my auto-formatting (which I simply forgot about before) and made the changes again. Exceptions that were previously logged and then thrown are now only thrown. If a special message was logged, that message is now the exception message of the exception being thrown.

I included the second commit I made, where some convenience methods in the OpcPackage were not closing filestreams which they opened.

Note that in my eclipse the project has 8 compile problems (before and after my changes) because org.eclipse.persistence was not on the buildpath and BindingHandler has no method getXpathsMap(). (I executed mvn install -DskipTests=true). As these were also in the cloned repo I hope these are just problems with my setup.
Note also that I just did `grep "catch" -n -r -A 2 . | grep "log\." -A 1 | grep throw`. Which searches for a catch, in the next line for a log. and then for a throw. So if there were a line with a comment or sth in between I didn't get that. 