### PR TITLE
Fix FieldUpdater bugs: Parts of document not updated fixed.

### DIFF
--- a/src/main/java/org/docx4j/model/fields/FieldUpdater.java
+++ b/src/main/java/org/docx4j/model/fields/FieldUpdater.java
@@ -219,11 +219,16 @@ public class FieldUpdater {
 				} catch (TransformerException e) {
 					e.printStackTrace();
 				}
-
-				String key = fsm.getFldParameters().get(0);
-				String val = (String) docPropertyResolver.getValue(key); 
+				String val = null;
+				String key = null;
 				try {
-				  val = (String) docPropertyResolver.getValue(key); 
+					// Safe checking when fldParameters is 0 (… and null just for good measure)
+					if (fsm.getFldParameters() != null && fsm.getFldParameters().size() > 0) {
+						key = fsm.getFldParameters().get(0);
+						// Maybe the actual bug many of us have. This solved it for me: Remove any " char that may appear in the key name
+						key = key.replaceAll("\"", "");
+						val = (String) docPropertyResolver.getValue(key);
+					}
 				} catch (FieldValueException e) {
 					report.append( instr + "\n");
 					report.append( key + " -> NOT FOUND! \n");	


### PR DESCRIPTION
This fixed the FieldUpdater for me.
1) Some safe array checks that were causing the process to fail
2) remove the quotes " from the key that caused the matching with existing properties to fail

This may be related to the following issues I saw when searching for a solution:

- https://www.docx4java.org/forums/docx-java-f6/exception-executing-custom-property-update-t2637.html

- https://github.com/plutext/docx4j/issues/244

PS: thanks Jason for the thread resurrection that brought me on the solution :)  https://www.docx4java.org/forums/docx-java-f6/word-document-template-properties-update-requires-manual-t916.html