### PR TITLE
[ISSUE] Multiple new lines

### DIFF
--- a/docx4j-core/src/main/java/org/docx4j/model/fields/FieldRef.java
+++ b/docx4j-core/src/main/java/org/docx4j/model/fields/FieldRef.java
@@ -522,12 +522,12 @@ public class FieldRef {
 	public void setResult(String val) {
 		
 		resultsSlot.getContent().clear();
-		StringTokenizer st = new StringTokenizer(val, "\n\r\f"); // tokenize on the newline character, the carriage-return character, and the form-feed character
+		String[] splitted = val.split("\\R");
 		
 		// our docfrag may contain several runs
 		boolean firsttoken = true;
-		while (st.hasMoreTokens()) {						
-			String line = (String) st.nextToken();
+		for (int i = 0; i < splitted.length; i++) {						
+			String line = splitted[i];
 			
 			if (firsttoken) {
 				firsttoken = false;


### PR DESCRIPTION
The StringTokenizer is a bad solution because it does not support multiple newline characters, ex. \n\n\n. IMHO, the better solution is the method split("\\R"), more info here: https://github.com/plutext/docx4j/commit/df64bd5ca0358e9cdcd7674b20d0df3469c55a2e