### PR TITLE
Add w:label to w:stdPr

### DIFF
--- a/docx4j-core-tests/src/test/java/org/docx4j/wml/SdtPrTest.java
+++ b/docx4j-core-tests/src/test/java/org/docx4j/wml/SdtPrTest.java
@@ -1,0 +1,68 @@
+package org.docx4j.wml;
+
+import org.docx4j.XmlUtils;
+import org.docx4j.openpackaging.exceptions.InvalidFormatException;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.xml.bind.JAXBElement;
+import javax.xml.bind.JAXBException;
+
+public class SdtPrTest {
+
+    /**
+     * Unmarshalling sets sdtcontentblock.getParent() correctly.
+     *
+     * @throws InvalidFormatException
+     * @throws JAXBException
+     */
+    @Test
+    public void testUnmarshallingAndMarshallingSdtContentBlock() throws InvalidFormatException, JAXBException {
+
+
+        String openXML = "<w:document mc:Ignorable=\"w14 wp14\" xmlns:cppr=\"http://schemas.microsoft.com/office/2006/coverPageProps\" xmlns:dgm1611=\"http://schemas.microsoft.com/office/drawing/2016/11/diagram\" xmlns:xdr=\"http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing\" xmlns:w16se=\"http://schemas.microsoft.com/office/word/2015/wordml/symex\" xmlns:wp15=\"http://schemas.microsoft.com/office/word/2012/wordprocessingDrawing\" xmlns:wp14=\"http://schemas.microsoft.com/office/word/2010/wordprocessingDrawing\" xmlns:pic=\"http://schemas.openxmlformats.org/drawingml/2006/picture\" xmlns:a1611=\"http://schemas.microsoft.com/office/drawing/2016/11/main\" xmlns:a16svg=\"http://schemas.microsoft.com/office/drawing/2016/SVG/main\" xmlns:am3d=\"http://schemas.microsoft.com/office/drawing/2017/model3d\" xmlns:pvml=\"urn:schemas-microsoft-com:office:powerpoint\" xmlns:mc=\"http://schemas.openxmlformats.org/markup-compatibility/2006\" xmlns:dgm1612=\"http://schemas.microsoft.com/office/drawing/2016/12/diagram\" xmlns:comp=\"http://schemas.openxmlformats.org/drawingml/2006/compatibility\" xmlns:xvml=\"urn:schemas-microsoft-com:office:excel\" xmlns:c173=\"http://schemas.microsoft.com/office/drawing/2017/03/chart\" xmlns:anam3d=\"http://schemas.microsoft.com/office/drawing/2018/animation/model3d\" xmlns:wpc=\"http://schemas.microsoft.com/office/word/2010/wordprocessingCanvas\" xmlns:adec=\"http://schemas.microsoft.com/office/drawing/2017/decorative\" xmlns:oda=\"http://opendope.org/answers\" xmlns:a18hc=\"http://schemas.microsoft.com/office/drawing/2018/hyperlinkcolor\" xmlns:odc=\"http://opendope.org/conditions\" xmlns:wpg=\"http://schemas.microsoft.com/office/word/2010/wordprocessingGroup\" xmlns:cdr=\"http://schemas.openxmlformats.org/drawingml/2006/chartDrawing\" xmlns:odi=\"http://opendope.org/components\" xmlns:msink=\"http://schemas.microsoft.com/ink/2010/main\" xmlns:cdr14=\"http://schemas.microsoft.com/office/drawing/2010/chartDrawing\" xmlns:iact=\"http://schemas.microsoft.com/office/powerpoint/2014/inkAction\" xmlns:an18=\"http://schemas.microsoft.com/office/drawing/2018/animation\" xmlns:wps=\"http://schemas.microsoft.com/office/word/2010/wordprocessingShape\" xmlns:odq=\"http://opendope.org/questions\" xmlns:w16cid=\"http://schemas.microsoft.com/office/word/2016/wordml/cid\" xmlns:dsp=\"http://schemas.microsoft.com/office/drawing/2008/diagram\" xmlns:odx=\"http://opendope.org/xpaths\" xmlns:a15=\"http://schemas.microsoft.com/office/drawing/2012/main\" xmlns:a14=\"http://schemas.microsoft.com/office/drawing/2010/main\" xmlns:c15=\"http://schemas.microsoft.com/office/drawing/2012/chart\" xmlns:a13cmd=\"http://schemas.microsoft.com/office/drawing/2013/main/command\" xmlns:c14=\"http://schemas.microsoft.com/office/drawing/2007/8/2/chart\" xmlns:a16=\"http://schemas.microsoft.com/office/drawing/2014/main\" xmlns:odgm=\"http://opendope.org/SmartArt/DataHierarchy\" xmlns:c16=\"http://schemas.microsoft.com/office/drawing/2014/chart\" xmlns:dgm=\"http://schemas.openxmlformats.org/drawingml/2006/diagram\" xmlns:thm15=\"http://schemas.microsoft.com/office/thememl/2012/main\" xmlns:we=\"http://schemas.microsoft.com/office/webextensions/webextension/2010/11\" xmlns:w10=\"urn:schemas-microsoft-com:office:word\" xmlns:ns39=\"http://www.w3.org/2003/InkML\" xmlns:wp=\"http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing\" xmlns:sl=\"http://schemas.openxmlformats.org/schemaLibrary/2006/main\" xmlns:ns38=\"http://www.w3.org/1998/Math/MathML\" xmlns:w15=\"http://schemas.microsoft.com/office/word/2012/wordml\" xmlns:w14=\"http://schemas.microsoft.com/office/word/2010/wordml\" xmlns:dgm14=\"http://schemas.microsoft.com/office/drawing/2010/diagram\" xmlns:c16ac=\"http://schemas.microsoft.com/office/drawing/2014/chart/ac\" xmlns:a=\"http://schemas.openxmlformats.org/drawingml/2006/main\" xmlns:b=\"http://schemas.openxmlformats.org/officeDocument/2006/bibliography\" xmlns:c=\"http://schemas.openxmlformats.org/drawingml/2006/chart\" xmlns:m=\"http://schemas.openxmlformats.org/officeDocument/2006/math\" xmlns:wne=\"http://schemas.microsoft.com/office/word/2006/wordml\" xmlns:o=\"urn:schemas-microsoft-com:office:office\" xmlns:cs=\"http://schemas.microsoft.com/office/drawing/2012/chartStyle\" xmlns:r=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships\" xmlns:cx=\"http://schemas.microsoft.com/office/drawing/2014/chartex\" xmlns:v=\"urn:schemas-microsoft-com:vml\" xmlns:pic14=\"http://schemas.microsoft.com/office/drawing/2010/picture\" xmlns:w=\"http://schemas.openxmlformats.org/wordprocessingml/2006/main\" xmlns:lc=\"http://schemas.openxmlformats.org/drawingml/2006/lockedCanvas\" xmlns:wetp=\"http://schemas.microsoft.com/office/webextensions/taskpanes/2010/11\">"
+                + "<w:body>"
+                + "<w:sdt>" // SdtBlock
+                + "<w:sdtPr>"
+                + "<w:id w:val=\"23345677\"/>"
+                + "<w:label w:val=\"labelVal\"/>"
+                + "<w:alias w:val=\"aliasVal\"/>"
+                + "<w:tag w:val=\"99f2055c-5fac-41f7-9125-a7a3276f4291\"/>"
+                + "</w:sdtPr>"
+
+                + "<w:sdtContent>" // SdtContentBlock
+                + "<w:p>"
+                + "<w:r>"
+                + "<w:t>Some content</w:t>"
+                + "</w:r>"
+                + "</w:p>"
+                + "</w:sdtContent>"
+
+                + "</w:sdt>"
+                + "</w:body>"
+
+                + "</w:document>"
+                ;
+
+        Document document = (Document) XmlUtils.unmarshalString(openXML);
+
+
+        SdtBlock sdtblock = (SdtBlock)document.getContent().get(0);
+
+
+        Assert.assertTrue(sdtblock.sdtPr.rPrOrAliasOrLock.get(0) instanceof Id);
+        Assert.assertTrue(sdtblock.sdtPr.rPrOrAliasOrLock.get(1) instanceof JAXBElement);
+        Assert.assertTrue(sdtblock.sdtPr.rPrOrAliasOrLock.get(2) instanceof JAXBElement);
+        Assert.assertTrue(((JAXBElement)sdtblock.sdtPr.rPrOrAliasOrLock.get(1)).getValue() instanceof SdtPr.Label);
+        Assert.assertTrue(((JAXBElement)sdtblock.sdtPr.rPrOrAliasOrLock.get(2)).getValue() instanceof SdtPr.Alias);
+        Assert.assertTrue(sdtblock.sdtPr.rPrOrAliasOrLock.get(3) instanceof Tag);
+        Assert.assertEquals(23345677L, ((Id) sdtblock.sdtPr.rPrOrAliasOrLock.get(0)).val.longValue());
+        Assert.assertEquals("labelVal", ((SdtPr.Label) ((JAXBElement)sdtblock.sdtPr.rPrOrAliasOrLock.get(1)).getValue()).val);
+        Assert.assertEquals("aliasVal", ((SdtPr.Alias) ((JAXBElement)sdtblock.sdtPr.rPrOrAliasOrLock.get(2)).getValue()).val);
+
+
+        String res = XmlUtils.marshaltoString(document, true, false);
+        Assert.assertEquals(openXML, res);
+    }
+}
+

--- a/docx4j-openxml-objects/src/main/java/org/docx4j/wml/ObjectFactory.java
+++ b/docx4j-openxml-objects/src/main/java/org/docx4j/wml/ObjectFactory.java
@@ -144,6 +144,7 @@ public class ObjectFactory {
     private final static QName _CTTrPrBaseHidden_QNAME = new QName("http://schemas.openxmlformats.org/wordprocessingml/2006/main", "hidden");
     private final static QName _SdtPrRPr_QNAME = new QName("http://schemas.openxmlformats.org/wordprocessingml/2006/main", "rPr");
     private final static QName _SdtPrAlias_QNAME = new QName("http://schemas.openxmlformats.org/wordprocessingml/2006/main", "alias");
+    private final static QName _SdtPrLabel_QNAME = new QName("http://schemas.openxmlformats.org/wordprocessingml/2006/main", "label");
     private final static QName _SdtPrLock_QNAME = new QName("http://schemas.openxmlformats.org/wordprocessingml/2006/main", "lock");
     private final static QName _SdtPrPlaceholder_QNAME = new QName("http://schemas.openxmlformats.org/wordprocessingml/2006/main", "placeholder");
     private final static QName _SdtPrShowingPlcHdr_QNAME = new QName("http://schemas.openxmlformats.org/wordprocessingml/2006/main", "showingPlcHdr");
@@ -5735,6 +5736,15 @@ public class ObjectFactory {
     @XmlElementDecl(namespace = "http://schemas.openxmlformats.org/wordprocessingml/2006/main", name = "lock", scope = SdtPr.class)
     public JAXBElement<CTLock> createSdtPrLock(CTLock value) {
         return new JAXBElement<CTLock>(_SdtPrLock_QNAME, CTLock.class, SdtPr.class, value);
+    }
+
+    /**
+     * Create an instance of {@link JAXBElement }{@code <}{@link SdtPr.Label }{@code >}}
+     *
+     */
+    @XmlElementDecl(namespace = "http://schemas.openxmlformats.org/wordprocessingml/2006/main", name = "label", scope = SdtPr.class)
+    public JAXBElement<SdtPr.Label> createSdtPrLabel(SdtPr.Label value) {
+        return new JAXBElement<SdtPr.Label>(_SdtPrLabel_QNAME, SdtPr.Label.class, SdtPr.class, value);
     }
 
     /**

--- a/docx4j-openxml-objects/src/main/java/org/docx4j/wml/SdtPr.java
+++ b/docx4j-openxml-objects/src/main/java/org/docx4j/wml/SdtPr.java
@@ -172,6 +172,7 @@ public class SdtPr
         @XmlElementRef(name = "placeholder", namespace = "http://schemas.openxmlformats.org/wordprocessingml/2006/main", type = JAXBElement.class),
         @XmlElementRef(name = "dataBinding", namespace = "http://schemas.microsoft.com/office/word/2012/wordml", type = JAXBElement.class),
         @XmlElementRef(name = "alias", namespace = "http://schemas.openxmlformats.org/wordprocessingml/2006/main", type = JAXBElement.class),
+        @XmlElementRef(name = "label", namespace = "http://schemas.openxmlformats.org/wordprocessingml/2006/main", type = JAXBElement.class),
         @XmlElementRef(name = "checkbox", namespace = "http://schemas.microsoft.com/office/word/2010/wordml", type = JAXBElement.class),
         @XmlElementRef(name = "showingPlcHdr", namespace = "http://schemas.openxmlformats.org/wordprocessingml/2006/main", type = JAXBElement.class),
         @XmlElementRef(name = "webExtensionCreated", namespace = "http://schemas.microsoft.com/office/word/2012/wordml", type = JAXBElement.class),
@@ -225,6 +226,7 @@ public class SdtPr
      * {@link JAXBElement }{@code <}{@link CTPlaceholder }{@code >}
      * {@link JAXBElement }{@code <}{@link CTDataBinding }{@code >}
      * {@link JAXBElement }{@code <}{@link SdtPr.Alias }{@code >}
+     * {@link JAXBElement }{@code <}{@link SdtPr.Label }{@code >}
      * {@link JAXBElement }{@code <}{@link CTSdtCheckbox }{@code >}
      * {@link JAXBElement }{@code <}{@link BooleanDefaultTrue }{@code >}
      * {@link JAXBElement }{@code <}{@link BooleanDefaultTrue }{@code >}
@@ -590,6 +592,87 @@ public class SdtPr
 
     }
 
+
+    /**
+     * <p>Java class for anonymous complex type.
+     *
+     * <p>The following schema fragment specifies the expected content contained within this class.
+     *
+     * <pre>
+     * &lt;complexType>
+     *   &lt;complexContent>
+     *     &lt;restriction base="{http://www.w3.org/2001/XMLSchema}anyType">
+     *       &lt;attribute name="val" type="{http://www.w3.org/2001/XMLSchema}string" />
+     *     &lt;/restriction>
+     *   &lt;/complexContent>
+     * &lt;/complexType>
+     * </pre>
+     *
+     *
+     */
+    @XmlAccessorType(XmlAccessType.FIELD)
+    @XmlType(name = "")
+    @XmlRootElement(name = "label")
+    public static class Label
+        implements Child
+    {
+
+        @XmlAttribute(name = "val", namespace = "http://schemas.openxmlformats.org/wordprocessingml/2006/main")
+        protected String val;
+        @XmlTransient
+        private Object parent;
+
+        /**
+         * Gets the value of the val property.
+         *
+         * @return
+         *     possible object is
+         *     {@link String }
+         *
+         */
+        public String getVal() {
+            return val;
+        }
+
+        /**
+         * Sets the value of the val property.
+         *
+         * @param value
+         *     allowed object is
+         *     {@link String }
+         *
+         */
+        public void setVal(String value) {
+            this.val = value;
+        }
+
+        /**
+         * Gets the parent object in the object tree representing the unmarshalled xml document.
+         *
+         * @return
+         *     The parent object.
+         */
+        public Object getParent() {
+            return this.parent;
+        }
+
+        public void setParent(Object parent) {
+            this.parent = parent;
+        }
+
+        /**
+         * This method is invoked by the JAXB implementation on each instance when unmarshalling completes.
+         *
+         * @param parent
+         *     The parent object in the object tree.
+         * @param unmarshaller
+         *     The unmarshaller that generated the instance.
+         */
+        public void afterUnmarshal(Unmarshaller unmarshaller, Object parent) {
+            setParent(parent);
+        }
+
+    }
 
     /**
      * <p>Java class for anonymous complex type.


### PR DESCRIPTION
In this standard ISO/IEC 29500-1:2016 in 17.5.2.19 (page 531) described "label (Structured Document Tag Label)" in "w:sdtPr".
I add binding for correct marshaling and unmarshalling.
And also add some tests.

From ISO/IEC 29500-1:2016
This element specifies the label identifier associated with the current structured document tag. The identifier representing the label shall be stored on this element’s val attribute and is used to reference the unique identifier value of a structured document tag.