### PR TITLE
cached effective rPr from pRPr

### DIFF
--- a/docx4j-core/src/main/java/org/docx4j/fonts/RunFontSelector.java
+++ b/docx4j-core/src/main/java/org/docx4j/fonts/RunFontSelector.java
@@ -22,6 +22,7 @@ import org.w3c.dom.DocumentFragment;
 import org.w3c.dom.Element;
 
 import java.awt.font.NumericShaper;
+import java.util.HashMap;
 import java.util.concurrent.ExecutionException;
 
 /**
@@ -67,7 +68,9 @@ public class RunFontSelector {
 
 	private WordprocessingMLPackage wordMLPackage;
 	private RunFontCharacterVisitor vis;
-		
+
+	private java.util.Map<String, RPr> resolvedEffectiveStyleRPrFromPStyle = new HashMap<String, RPr>();
+
 	private RunFontActionType outputType;
 	public enum RunFontActionType {
 		XSL_FO,
@@ -366,9 +369,16 @@ public class RunFontSelector {
 
     	
     	// now apply the direct rPr
-    	rPr = propertyResolver.getEffectiveRPrUsingPStyleRPr(rPr, pRPr); 
+
+		// cache effective rPr
+		String effectiveRPrKey = buildEffectiveRPrKey(rPr, pRPr);
+		if (resolvedEffectiveStyleRPrFromPStyle.get(effectiveRPrKey) != null) {
+			rPr = resolvedEffectiveStyleRPrFromPStyle.get(effectiveRPrKey);
+		} else {
+			rPr = propertyResolver.getEffectiveRPrUsingPStyleRPr(rPr, pRPr);
+			resolvedEffectiveStyleRPrFromPStyle.put(effectiveRPrKey, rPr);
+		}
     	// TODO use effective rPr, but don't inherit theme val,
-    	// TODO, add cache?
 
     	if(log.isDebugEnabled()) {
             log.debug("effective\n" + XmlUtils.marshaltoString(rPr));
@@ -588,8 +598,20 @@ public class RunFontSelector {
 		return unicodeRangeToFont(text,  hint,  langEastAsia,
 	    		 eastAsia,  ascii,  hAnsi );
     }
-    
-    private boolean contains(String langEastAsia, String lang) {
+
+	private String buildEffectiveRPrKey(RPr rPr, RPr pRPr) {
+		String left = "";
+		String right = "";
+		if (rPr != null && pRPr.getRStyle() != null) {
+			left = rPr.getRStyle().getVal();
+		}
+		if (pRPr != null && pRPr.getRStyle() != null) {
+			right = pRPr.getRStyle().getVal();
+		}
+		return new StringBuilder().append(left).append("_").append(right).toString();
+	}
+
+	private boolean contains(String langEastAsia, String lang) {
     	
     	// eg <w:lang w:eastAsia="zh-CN" .. />
     	if (langEastAsia==null) return false;


### PR DESCRIPTION
This cache can improve the performance dramatically, because it avoided the deepCopy of pRPr a lot.

For a docx of 370 pages, the time reduced from 15 seconds to 5 seconds.