### PR TITLE
Fix docx4j on Websphere Liberty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,14 @@
 .settings/
 bin/
-target/
 /dist/
 bin-testOutput/
 .directory
-.idea
 .project
 .classpath
 .flattened-pom.xml
 tmp/
 release-zips/
 patches/
+**/target/*
+*.iml
+**/.idea/*

--- a/docx4j-JAXB-Internal/src/main/java/org/docx4j/jaxb/suninternal/NamespacePrefixMapper.java
+++ b/docx4j-JAXB-Internal/src/main/java/org/docx4j/jaxb/suninternal/NamespacePrefixMapper.java
@@ -25,7 +25,7 @@ import org.docx4j.jaxb.NamespacePrefixMapperInterface;
 import org.docx4j.jaxb.NamespacePrefixMapperUtils;
 import org.docx4j.jaxb.NamespacePrefixMappings;
 
-public class NamespacePrefixMapper extends com.sun.xml.internal.bind.marshaller.NamespacePrefixMapper  implements NamespacePrefixMapperInterface, McIgnorableNamespaceDeclarator {
+public class NamespacePrefixMapper extends com.sun.xml.bind.marshaller.NamespacePrefixMapper  implements NamespacePrefixMapperInterface, McIgnorableNamespaceDeclarator {
 
 	// Must use 'internal' for Java 6
 	

--- a/docx4j-JAXB-Internal/src/main/java/org/docx4j/jaxb/suninternal/NamespacePrefixMapperRelationshipsPart.java
+++ b/docx4j-JAXB-Internal/src/main/java/org/docx4j/jaxb/suninternal/NamespacePrefixMapperRelationshipsPart.java
@@ -23,7 +23,7 @@ package org.docx4j.jaxb.suninternal;
 import org.docx4j.jaxb.McIgnorableNamespaceDeclarator;
 import org.docx4j.jaxb.NamespacePrefixMapperInterface;
 
-public class NamespacePrefixMapperRelationshipsPart extends com.sun.xml.internal.bind.marshaller.NamespacePrefixMapper  implements NamespacePrefixMapperInterface, McIgnorableNamespaceDeclarator {
+public class NamespacePrefixMapperRelationshipsPart extends com.sun.xml.bind.marshaller.NamespacePrefixMapper  implements NamespacePrefixMapperInterface, McIgnorableNamespaceDeclarator {
 
 	// Must use 'internal' for Java 6
 

--- a/docx4j-JAXB-ReferenceImpl/pom.xml
+++ b/docx4j-JAXB-ReferenceImpl/pom.xml
@@ -68,12 +68,6 @@
 			<version>${project.version}</version>
 		</dependency>
 		
-		<dependency>
-		  <groupId>org.glassfish.jaxb</groupId>
-		  <artifactId>jaxb-runtime</artifactId>
-		  <version>2.3.2</version>
-		</dependency>		
-		
 <!--  
 
 	For Maven artifacts, see https://github.com/eclipse-ee4j/jaxb-ri#maven-artifacts

--- a/docx4j-JAXB-ReferenceImpl/src/test/java/org/docx4j/jaxb/ri/MarshalTest.java
+++ b/docx4j-JAXB-ReferenceImpl/src/test/java/org/docx4j/jaxb/ri/MarshalTest.java
@@ -1,5 +1,6 @@
 package org.docx4j.jaxb.ri;
 
+import com.sun.xml.bind.v2.ContextFactory;
 import org.docx4j.XmlUtils;
 import org.docx4j.jaxb.Context;
 import org.docx4j.jaxb.NamespacePrefixMapperUtils;
@@ -17,7 +18,7 @@ public class MarshalTest {
 	public void JAXBImplementationTest() throws JAXBException {
 
 		java.lang.ClassLoader classLoader = NamespacePrefixMapperUtils.class.getClassLoader();
-		JAXBContext testContext = JAXBContext.newInstance("org.docx4j.relationships",classLoader );
+		JAXBContext testContext = ContextFactory.createContext("org.docx4j.relationships",classLoader, null);
 		
         assertEquals("com.sun.xml.bind.v2.runtime.JAXBContextImpl", testContext.getClass().getName() );
 	}

--- a/docx4j-core/pom.xml
+++ b/docx4j-core/pom.xml
@@ -395,6 +395,11 @@
 	      <version>1.0.1</version>
 	    </dependency>
 		 -->
+		<dependency>
+			<groupId>org.glassfish.jaxb</groupId>
+			<artifactId>jaxb-runtime</artifactId>
+			<version>2.3.2</version>
+		</dependency>
 	</dependencies>
 	
 </project>

--- a/docx4j-core/src/main/java/org/docx4j/convert/in/word2003xml/Word2003XmlConverter.java
+++ b/docx4j-core/src/main/java/org/docx4j/convert/in/word2003xml/Word2003XmlConverter.java
@@ -14,6 +14,7 @@ import javax.xml.transform.Templates;
 import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.stream.StreamSource;
 
+import com.sun.xml.bind.v2.ContextFactory;
 import org.apache.commons.io.FileUtils;
 import org.docx4j.XmlUtils;
 import org.docx4j.openpackaging.exceptions.Docx4JException;
@@ -65,7 +66,7 @@ public class Word2003XmlConverter {
 		java.lang.ClassLoader classLoader = Word2003XmlConverter.class.getClassLoader();		
 		
 		JAXBResult result = new JAXBResult(
-		         JAXBContext.newInstance("org.docx4j.convert.in.word2003xml", classLoader) );
+				ContextFactory.createContext("org.docx4j.convert.in.word2003xml", classLoader, null) );
 		XmlUtils.transform(source, xslt, null, result);
 		
 		// set the unmarshalled content tree

--- a/docx4j-core/src/main/java/org/docx4j/fonts/BestMatchingMapper.java
+++ b/docx4j-core/src/main/java/org/docx4j/fonts/BestMatchingMapper.java
@@ -28,6 +28,7 @@ import java.util.Set;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.Unmarshaller;
 
+import com.sun.xml.bind.v2.ContextFactory;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -131,7 +132,7 @@ public class BestMatchingMapper extends Mapper {
 	private final static void setupMicrosoftFontFilenames() throws Exception {
 
 		java.lang.ClassLoader classLoader = BestMatchingMapper.class.getClassLoader();				
-		JAXBContext msFontsContext = JAXBContext.newInstance("org.docx4j.fonts.microsoft", classLoader);
+		JAXBContext msFontsContext = ContextFactory.createContext("org.docx4j.fonts.microsoft", classLoader, null);
 		
 		Unmarshaller u = msFontsContext.createUnmarshaller();		
 		u.setEventHandler(new org.docx4j.jaxb.JaxbValidationEventHandler());
@@ -193,7 +194,7 @@ public class BestMatchingMapper extends Mapper {
 	private final static void setupExplicitSubstitutionsMap() throws Exception {
 				
 		java.lang.ClassLoader classLoader = BestMatchingMapper.class.getClassLoader();						
-		JAXBContext substitutionsContext = JAXBContext.newInstance("org.docx4j.fonts.substitutions", classLoader);
+		JAXBContext substitutionsContext = ContextFactory.createContext("org.docx4j.fonts.substitutions", classLoader, null);
 		
 		Unmarshaller u2 = substitutionsContext.createUnmarshaller();		
 		u2.setEventHandler(new org.docx4j.jaxb.JaxbValidationEventHandler());

--- a/docx4j-core/src/main/java/org/docx4j/fonts/microsoft/MicrosoftFontsRegistry.java
+++ b/docx4j-core/src/main/java/org/docx4j/fonts/microsoft/MicrosoftFontsRegistry.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.Unmarshaller;
 
+import com.sun.xml.bind.v2.ContextFactory;
 import org.docx4j.utils.ResourceUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,7 +46,7 @@ public class MicrosoftFontsRegistry {
 //		filenamesToMsFontNames = new HashMap<String, String>();
 		
 		java.lang.ClassLoader classLoader = MicrosoftFontsRegistry.class.getClassLoader();		
-		JAXBContext msFontsContext = JAXBContext.newInstance("org.docx4j.fonts.microsoft", classLoader);
+		JAXBContext msFontsContext = ContextFactory.createContext("org.docx4j.fonts.microsoft", classLoader, null);
 		
 		Unmarshaller u = msFontsContext.createUnmarshaller();		
 		u.setEventHandler(new org.docx4j.jaxb.JaxbValidationEventHandler());

--- a/docx4j-core/src/main/java/org/docx4j/jaxb/Context.java
+++ b/docx4j-core/src/main/java/org/docx4j/jaxb/Context.java
@@ -31,6 +31,8 @@ import java.util.jar.Manifest;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 
+import com.sun.xml.bind.v2.ContextFactory;
+import com.sun.xml.bind.v2.JAXBContextFactory;
 import org.apache.commons.io.IOUtils;
 import org.docx4j.utils.ResourceUtils;
 import org.slf4j.Logger;
@@ -103,7 +105,7 @@ public class Context {
 		
       
       try { 
-			// JAXBContext.newInstance uses the context class loader of the current thread. 
+			// ContextFactory.createContext uses the context class loader of the current thread.
 			// To specify the use of a different class loader, 
 			// either set it via the Thread.setContextClassLoader() api 
 			// or use the newInstance method.
@@ -117,7 +119,7 @@ public class Context {
     	  
 			java.lang.ClassLoader classLoader = Context.class.getClassLoader();
 
-			tempContext = JAXBContext.newInstance("org.docx4j.wml:org.docx4j.w14:org.docx4j.w15:" +
+			tempContext = ContextFactory.createContext("org.docx4j.wml:org.docx4j.w14:org.docx4j.w15:" +
 					"org.docx4j.com.microsoft.schemas.office.word.x2006.wordml:" +
 					"org.docx4j.dml:org.docx4j.dml.chart:org.docx4j.dml.chart.x2007:org.docx4j.dml.chartDrawing:org.docx4j.dml.compatibility:org.docx4j.dml.diagram:org.docx4j.dml.lockedCanvas:org.docx4j.dml.picture:org.docx4j.dml.wordprocessingDrawing:org.docx4j.dml.spreadsheetdrawing:org.docx4j.dml.diagram2008:" +
 					// All VML stuff is here, since compiling it requires WML and DML (and MathML), but not PML or SML
@@ -222,21 +224,21 @@ public class Context {
 			} else {
 				log.warn("Using unexpected JAXB: " + tempContext.getClass().getName());
 			}
+
+			jcThemePart = tempContext; //ContextFactory.createContext("org.docx4j.dml",classLoader );
+			jcDocPropsCore = ContextFactory.createContext("org.docx4j.docProps.core:org.docx4j.docProps.core.dc.elements:org.docx4j.docProps.core.dc.terms",classLoader, ProviderProperties.getProviderProperties() );
+			jcDocPropsCustom = ContextFactory.createContext("org.docx4j.docProps.custom",classLoader, ProviderProperties.getProviderProperties() );
+			jcDocPropsExtended = ContextFactory.createContext("org.docx4j.docProps.extended",classLoader, ProviderProperties.getProviderProperties() );
+			jcXmlPackage = ContextFactory.createContext("org.docx4j.xmlPackage",classLoader, ProviderProperties.getProviderProperties() );
+			jcRelationships = ContextFactory.createContext("org.docx4j.relationships",classLoader, ProviderProperties.getProviderProperties() );
+			jcCustomXmlProperties = ContextFactory.createContext("org.docx4j.customXmlProperties",classLoader, ProviderProperties.getProviderProperties() );
+			jcContentTypes = ContextFactory.createContext("org.docx4j.openpackaging.contenttype",classLoader, ProviderProperties.getProviderProperties() );
 			
-			jcThemePart = tempContext; //JAXBContext.newInstance("org.docx4j.dml",classLoader );
-			jcDocPropsCore = JAXBContext.newInstance("org.docx4j.docProps.core:org.docx4j.docProps.core.dc.elements:org.docx4j.docProps.core.dc.terms",classLoader, ProviderProperties.getProviderProperties() );
-			jcDocPropsCustom = JAXBContext.newInstance("org.docx4j.docProps.custom",classLoader, ProviderProperties.getProviderProperties() );
-			jcDocPropsExtended = JAXBContext.newInstance("org.docx4j.docProps.extended",classLoader, ProviderProperties.getProviderProperties() );
-			jcXmlPackage = JAXBContext.newInstance("org.docx4j.xmlPackage",classLoader, ProviderProperties.getProviderProperties() );
-			jcRelationships = JAXBContext.newInstance("org.docx4j.relationships",classLoader, ProviderProperties.getProviderProperties() );
-			jcCustomXmlProperties = JAXBContext.newInstance("org.docx4j.customXmlProperties",classLoader, ProviderProperties.getProviderProperties() );
-			jcContentTypes = JAXBContext.newInstance("org.docx4j.openpackaging.contenttype",classLoader, ProviderProperties.getProviderProperties() );
-			
-			jcSectionModel = JAXBContext.newInstance("org.docx4j.model.structure.jaxb",classLoader, ProviderProperties.getProviderProperties() );
+			jcSectionModel = ContextFactory.createContext("org.docx4j.model.structure.jaxb",classLoader, ProviderProperties.getProviderProperties() );
 			
 			try {
-				//jcXmlDSig = JAXBContext.newInstance("org.plutext.jaxb.xmldsig",classLoader );
-				jcEncryption = JAXBContext.newInstance(
+				//jcXmlDSig = ContextFactory.createContext("org.plutext.jaxb.xmldsig",classLoader );
+				jcEncryption = ContextFactory.createContext(
 						 "org.docx4j.com.microsoft.schemas.office.x2006.encryption:"
 						+ "org.docx4j.com.microsoft.schemas.office.x2006.keyEncryptor.certificate:"
 						+ "org.docx4j.com.microsoft.schemas.office.x2006.keyEncryptor.password:"
@@ -245,7 +247,7 @@ public class Context {
 				log.error(e.getMessage());
 			}
 
-			jcMCE = JAXBContext.newInstance("org.docx4j.mce",classLoader, ProviderProperties.getProviderProperties() );
+			jcMCE = ContextFactory.createContext("org.docx4j.mce",classLoader, ProviderProperties.getProviderProperties() );
 			
 			log.debug(".. other contexts loaded ..");
 										
@@ -274,7 +276,7 @@ public class Context {
 				Context tmp = new Context();
 				java.lang.ClassLoader classLoader = tmp.getClass().getClassLoader();
 
-				jcXslFo = JAXBContext.newInstance("org.plutext.jaxb.xslfo",classLoader );
+				jcXslFo = ContextFactory.createContext("org.plutext.jaxb.xslfo",classLoader, null);
 				
 			} catch (JAXBException ex) {
 	      log.error("Cannot determine XSL-FO context", ex);

--- a/docx4j-core/src/main/java/org/docx4j/jaxb/NamespacePrefixMapperUtils.java
+++ b/docx4j-core/src/main/java/org/docx4j/jaxb/NamespacePrefixMapperUtils.java
@@ -11,6 +11,7 @@ import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
 
+import com.sun.xml.bind.v2.ContextFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -36,7 +37,7 @@ public class NamespacePrefixMapperUtils {
 				
 		if (testContext==null) {
 			java.lang.ClassLoader classLoader = NamespacePrefixMapperUtils.class.getClassLoader();
-			testContext = JAXBContext.newInstance("org.docx4j.relationships",classLoader );
+			testContext = ContextFactory.createContext("org.docx4j.relationships",classLoader, null);
 		}
 		
 		if (testContext==null) {
@@ -52,8 +53,8 @@ public class NamespacePrefixMapperUtils {
 				throw new JAXBException("Can't create org.docx4j.jaxb.moxy.NamespacePrefixMapper", e);
 			}
 		}
-		if (testContext.getClass().getName().equals("com.sun.xml.internal.bind.v2.runtime.JAXBContextImpl")) {
-			log.info("Using com.sun.xml.internal NamespacePrefixMapper");
+		if (testContext.getClass().getName().equals("com.sun.xml.bind.v2.runtime.JAXBContextImpl")) {
+			log.info("Using com.sun.xml NamespacePrefixMapper");
 			try {
 				Class c = Class.forName("org.docx4j.jaxb.suninternal.NamespacePrefixMapper");
 				prefixMapper = c.newInstance();
@@ -98,7 +99,7 @@ public class NamespacePrefixMapperUtils {
 
 		if (testContext==null) {
 			java.lang.ClassLoader classLoader = NamespacePrefixMapperUtils.class.getClassLoader();
-			testContext = JAXBContext.newInstance("org.docx4j.relationships",classLoader );
+			testContext = ContextFactory.createContext("org.docx4j.relationships",classLoader, null);
 		}
 		
 		if (testContext==null) {
@@ -115,7 +116,7 @@ public class NamespacePrefixMapperUtils {
 				throw new JAXBException("Can't create org.docx4j.jaxb.moxy.NamespacePrefixMapper", e);
 			}
 		}
-		if (testContext.getClass().getName().equals("com.sun.xml.internal.bind.v2.runtime.JAXBContextImpl")) {
+		if (testContext.getClass().getName().equals("com.sun.xml.bind.v2.runtime.JAXBContextImpl")) {
 			log.info("Using com.sun.xml.internal NamespacePrefixMapper");
 			try {
 				Class c = Class.forName("org.docx4j.jaxb.suninternal.NamespacePrefixMapperRelationshipsPart");

--- a/docx4j-core/src/main/java/org/pptx4j/convert/out/svginhtml/SvgExporter.java
+++ b/docx4j-core/src/main/java/org/pptx4j/convert/out/svginhtml/SvgExporter.java
@@ -11,6 +11,7 @@ import javax.xml.transform.Templates;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 
+import com.sun.xml.bind.v2.ContextFactory;
 import org.docx4j.XmlUtils;
 import org.docx4j.convert.out.AbstractConversionSettings;
 import org.docx4j.convert.out.html.HtmlCssHelper;
@@ -71,7 +72,7 @@ public class SvgExporter {
 	static {
 		
 		try {
-			jcSVG = JAXBContext.newInstance("org.plutext.jaxb.svg11");
+			jcSVG = ContextFactory.createContext("org.plutext.jaxb.svg11", SvgExporter.class.getClassLoader(), null);
 			oFactory = new ObjectFactory();
 
 			Source xsltSource = new StreamSource(

--- a/docx4j-core/src/main/java/org/pptx4j/jaxb/Context.java
+++ b/docx4j-core/src/main/java/org/pptx4j/jaxb/Context.java
@@ -22,6 +22,7 @@ package org.pptx4j.jaxb;
 
 import javax.xml.bind.JAXBContext;
 
+import com.sun.xml.bind.v2.ContextFactory;
 import org.docx4j.jaxb.ProviderProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,7 +60,7 @@ public class Context {
 			
 			java.lang.ClassLoader classLoader = Context.class.getClassLoader();
 
-			jcPML = JAXBContext.newInstance("org.pptx4j.pml:" +
+			jcPML = ContextFactory.createContext("org.pptx4j.pml:" +
 					"org.docx4j.dml:org.docx4j.dml.chart:org.docx4j.dml.chartDrawing:org.docx4j.dml.compatibility:org.docx4j.dml.diagram:org.docx4j.dml.lockedCanvas:org.docx4j.dml.picture:org.docx4j.dml.wordprocessingDrawing:org.docx4j.dml.spreadsheetdrawing:" +
 					"org.pptx4j.com.microsoft.schemas.office.powerpoint.x2010.main:" +
 					"org.pptx4j.com.microsoft.schemas.office.powerpoint.x2012.main:" +

--- a/docx4j-core/src/main/java/org/xlsx4j/jaxb/Context.java
+++ b/docx4j-core/src/main/java/org/xlsx4j/jaxb/Context.java
@@ -22,6 +22,7 @@ package org.xlsx4j.jaxb;
 
 import javax.xml.bind.JAXBContext;
 
+import com.sun.xml.bind.v2.ContextFactory;
 import org.docx4j.jaxb.ProviderProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -58,7 +59,7 @@ public class Context {
 			
 			java.lang.ClassLoader classLoader = Context.class.getClassLoader();
 				
-			jcSML = JAXBContext.newInstance("org.xlsx4j.sml:" +
+			jcSML = ContextFactory.createContext("org.xlsx4j.sml:" +
 					"org.xlsx4j.schemas.microsoft.com.office.excel.x2010.spreadsheetDrawing:" +	
 					"org.xlsx4j.schemas.microsoft.com.office.excel_2006.main:" +
 					"org.xlsx4j.schemas.microsoft.com.office.excel_2008_2.main",classLoader, ProviderProperties.getProviderProperties() );


### PR DESCRIPTION
No longer rely on com.sun.xml.internal classes and use Glassfish JAXB Reference Implementation ContextFactory to create JAXBContext. This ensures that Websphere Liberty's internal JAXB imlpementation is not used, but the provided Glassfish JAXB RI is used.