### PR TITLE
Fix docx4j on Websphere Liberty

### DIFF
--- a/docx4j-JAXB-Glassfish/README.md
+++ b/docx4j-JAXB-Glassfish/README.md
@@ -1,0 +1,4 @@
+docx4j-JAXB-Glassfish
+=========================
+
+Add this jar if you want docx4j to add the glassfish reference implementation to your application. Includes a "hard" reference to this jaxb implementation and uses hardwired methods to get the JAXBContext.

--- a/docx4j-JAXB-Glassfish/pom.xml
+++ b/docx4j-JAXB-Glassfish/pom.xml
@@ -8,39 +8,21 @@
 	<version>${revision}</version>
   </parent>
   
-	<artifactId>docx4j-JAXB-Internal</artifactId>
+	<artifactId>docx4j-JAXB-Glassfish</artifactId>
 	<packaging>${packaging.type}</packaging>
-	<name>docx4j-JAXB-Internal</name>
+	<name>docx4j-JAXB-Glassfish</name>
 
 	<description>
-		config specifying that docx4j should use the JAXB Internal implementation (which is available but deprecated in Java 9 and 10) 
+		Config specifying, that packages and uses the Glassfish implementation hardwired
 	</description>
 
 	<build>
 		<plugins>
-		
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.8.0</version>
-				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
-					<!--  avoid package com.sun.xml.internal.bind.marshaller does not exist 
-					
-					https://bugs.java.com/bugdatabase/view_bug.do?bug_id=6778491
-					-->
-					<fork>true</fork>
-				    <compilerArgs>
-			        	<arg>-XDignore.symbol.file</arg>
-				    </compilerArgs>
-				</configuration>
-			</plugin>
 
 			<plugin>
 				<artifactId>maven-resources-plugin</artifactId>
 			</plugin>
-
+			
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
@@ -52,25 +34,31 @@
                         <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Name>${project.artifactId}</Bundle-Name>
                         <Bundle-Version>${project.version}</Bundle-Version>
-                        <!--  include this?                        
+                        <!--  include this?
                         <Import-Package>
 							org.docx4j.jaxb,
-                        	com.sun.xml.internal.bind
-                        </Import-Package> 
-                        -->
+							com.sun.xml.bind.marshaller
+						</Import-Package>  
+						 -->                      
                         <Export-Package>
-													org.docx4j.jaxb.ri,org.docx4j.jaxb.generic
-												</Export-Package>
-                        <!--  ?                        
-                        <_runsystempackages>com.sun.xml.internal.bind</_runsystempackages>
-                        -->
+                            org.docx4j.jaxb.ri,org.docx4j.jaxb.generic
+                        </Export-Package>
                     </instructions>
                 </configuration>
             </plugin>				
- 			
+			
+ 			<!--  mvn versions:display-dependency-updates --> 
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>versions-maven-plugin</artifactId>
+				<version>2.3</version>
+				<configuration>
+					<rulesUri>file:///${project.basedir}/rules.xml</rulesUri>
+				</configuration>
+			</plugin> 
+			
 		</plugins>
-</build>	
-
+	</build>
 
 	<dependencies>
 
@@ -79,8 +67,12 @@
 			<artifactId>docx4j-core</artifactId>
 			<version>${project.version}</version>
 		</dependency>
-	
+		<dependency>
+			<groupId>org.glassfish.jaxb</groupId>
+			<artifactId>jaxb-runtime</artifactId>
+			<version>2.3.2</version>
+		</dependency>
 		
-		</dependencies>
+	</dependencies>
 
 </project>

--- a/docx4j-JAXB-Glassfish/src/main/java/org/docx4j/jaxb/generic/ContextHelperImpl.java
+++ b/docx4j-JAXB-Glassfish/src/main/java/org/docx4j/jaxb/generic/ContextHelperImpl.java
@@ -1,0 +1,16 @@
+package org.docx4j.jaxb.generic;
+
+import com.sun.xml.bind.v2.ContextFactory;
+import java.util.Map;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+
+public class ContextHelperImpl extends org.docx4j.jaxb.generic.ContextHelper.ContextFactory {
+
+
+  @Override
+  JAXBContext createContext(String contextPath, ClassLoader classLoader,
+      Map<String, Object> properties) throws JAXBException {
+    return ContextFactory.createContext(contextPath, classLoader, properties);
+  }
+}

--- a/docx4j-JAXB-Glassfish/src/main/java/org/docx4j/jaxb/ri/NamespacePrefixMapper.java
+++ b/docx4j-JAXB-Glassfish/src/main/java/org/docx4j/jaxb/ri/NamespacePrefixMapper.java
@@ -1,0 +1,220 @@
+/*
+ *  Copyright 2007-2019, Plutext Pty Ltd.
+ *   
+ *  This file is part of docx4j.
+
+    docx4j is licensed under the Apache License, Version 2.0 (the "License"); 
+    you may not use this file except in compliance with the License. 
+
+    You may obtain a copy of the License at 
+
+        http://www.apache.org/licenses/LICENSE-2.0 
+
+    Unless required by applicable law or agreed to in writing, software 
+    distributed under the License is distributed on an "AS IS" BASIS, 
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+    See the License for the specific language governing permissions and 
+    limitations under the License.
+
+ */
+
+package org.docx4j.jaxb.ri;
+
+import org.docx4j.jaxb.McIgnorableNamespaceDeclarator;
+import org.docx4j.jaxb.NamespacePrefixMapperInterface;
+import org.docx4j.jaxb.NamespacePrefixMapperUtils;
+import org.docx4j.jaxb.NamespacePrefixMappings;
+
+public class NamespacePrefixMapper extends com.sun.xml.bind.marshaller.NamespacePrefixMapper 
+	implements NamespacePrefixMapperInterface, McIgnorableNamespaceDeclarator {
+	
+	private String mcIgnorable;
+	public void setMcIgnorable(String mcIgnorable) {
+		this.mcIgnorable = mcIgnorable;
+	}
+
+	/**
+     * Returns a preferred prefix for the given namespace URI.
+     * 
+     * This method is intended to be overrided by a derived class.
+     * 
+     * @param namespaceUri
+     *      The namespace URI for which the prefix needs to be found.
+     *      Never be null. "" is used to denote the default namespace.
+     * @param suggestion
+     *      When the content tree has a suggestion for the prefix
+     *      to the given namespaceUri, that suggestion is passed as a
+     *      parameter. Typically this value comes from QName.getPrefix()
+     *      to show the preference of the content tree. This parameter
+     *      may be null, and this parameter may represent an already
+     *      occupied prefix. 
+     * @param requirePrefix
+     *      If this method is expected to return non-empty prefix.
+     *      When this flag is true, it means that the given namespace URI
+     *      cannot be set as the default namespace.
+     * 
+     * @return
+     *      null if there's no preferred prefix for the namespace URI.
+     *      In this case, the system will generate a prefix for you.
+     * 
+     *      Otherwise the system will try to use the returned prefix,
+     *      but generally there's no guarantee if the prefix will be
+     *      actually used or not.
+     * 
+     *      return "" to map this namespace URI to the default namespace.
+     *      Again, there's no guarantee that this preference will be
+     *      honored.
+     * 
+     *      If this method returns "" when requirePrefix=true, the return
+     *      value will be ignored and the system will generate one.
+     */
+    public String getPreferredPrefix(String namespaceUri, String suggestion, boolean requirePrefix) 
+    // Implement the interface
+    {    	
+    	return NamespacePrefixMappings.getPreferredPrefixStatic(namespaceUri, suggestion, requirePrefix);    	
+    }
+
+// Where used???    
+//    public static String getPreferredPrefix(String namespaceUri) 
+//    // Implement the interface
+//    {    	
+//    	return NamespacePrefixMappings.getPreferredPrefixStatic(namespaceUri, null, false);    	
+//    }
+    
+    /**
+     * Returns a list of namespace URIs that should be declared
+     * at the root element.
+     * <p>
+     * By default, the JAXB RI produces namespace declarations only when
+     * they are necessary, only at where they are used. Because of this
+     * lack of look-ahead, sometimes the marshaller produces a lot of
+     * namespace declarations that look redundant to human eyes. For example,
+     * <pre><xmp>
+     * <?xml version="1.0"?>
+     * <root>
+     *   <ns1:child xmlns:ns1="urn:foo"> ... </ns1:child>
+     *   <ns2:child xmlns:ns2="urn:foo"> ... </ns2:child>
+     *   <ns3:child xmlns:ns3="urn:foo"> ... </ns3:child>
+     *   ...
+     * </root>
+     * <xmp></pre>
+     * <p>
+     * If you know in advance that you are going to use a certain set of
+     * namespace URIs, you can override this method and have the marshaller
+     * declare those namespace URIs at the root element. 
+     * <p>
+     * For example, by returning <code>new String[]{"urn:foo"}</code>,
+     * the marshaller will produce:
+     * <pre><xmp>
+     * <?xml version="1.0"?>
+     * <root xmlns:ns1="urn:foo">
+     *   <ns1:child> ... </ns1:child>
+     *   <ns1:child> ... </ns1:child>
+     *   <ns1:child> ... </ns1:child>
+     *   ...
+     * </root>
+     * <xmp></pre>
+     * <p>
+     * To control prefixes assigned to those namespace URIs, use the
+     * {@link #getPreferredPrefix} method. 
+     * 
+     * @return
+     *      A list of namespace URIs as an array of {@link String}s.
+     *      This method can return a length-zero array but not null.
+     *      None of the array component can be null. To represent
+     *      the empty namespace, use the empty string <code>""</code>.
+     * 
+     * @since
+     *      JAXB RI 1.0.2 
+     */
+    public String[] getPreDeclaredNamespaceUris() {
+    	return NamespacePrefixMapperUtils.getPreDeclaredNamespaceUris(mcIgnorable);
+    }
+    
+    /**
+     * Similar to {@link #getPreDeclaredNamespaceUris()} but allows the
+     * (prefix,nsUri) pairs to be returned.
+     *
+     * <p>
+     * With {@link #getPreDeclaredNamespaceUris()}, applications who wish to control
+     * the prefixes as well as the namespaces needed to implement both
+     * {@link #getPreDeclaredNamespaceUris()} and {@link #getPreferredPrefix(String, String, boolean)}.
+     *
+     * <p>
+     * This version eliminates the needs by returning an array of pairs.
+     *
+     * @return
+     *      always return a non-null (but possibly empty) array. The array stores
+     *      data like (prefix1,nsUri1,prefix2,nsUri2,...) Use an empty string to represent
+     *      the empty namespace URI and the default prefix. Null is not allowed as a value
+     *      in the array.
+     *
+     * @since
+     *      JAXB RI 2.0 beta
+     */
+//    public String[] getPreDeclaredNamespaceUris2() {    	
+//      return EMPTY_STRING;    	
+//    }
+    
+    /*  WARNING: don't use getPreDeclaredNamespaceUris2; it is buggy, at least in Java 1.6.0_27
+     * 
+		Attribute "xmlns:w14" was already specified for element "w:document".
+		org.xml.sax.SAXParseException: Attribute "xmlns:w14" was already specified for element "w:document".
+			at com.sun.org.apache.xerces.internal.parsers.DOMParser.parse(Unknown Source)
+			at com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderImpl.parse(Unknown Source)
+			at org.docx4j.org.apache.xml.security.utils.XMLUtils$DocumentBuilderProxy.parse(XMLUtils.java:1140)
+			at org.docx4j.org.apache.xml.security.c14n.Canonicalizer.canonicalize(Canonicalizer.java:286)
+	     */
+
+    /**
+     * Returns a list of (prefix,namespace URI) pairs that represents
+     * namespace bindings available on ancestor elements (that need not be repeated
+     * by the JAXB RI.)
+     *
+     * <p>
+     * Sometimes JAXB is used to marshal an XML document, which will be
+     * used as a subtree of a bigger document. When this happens, it's nice
+     * for a JAXB marshaller to be able to use in-scope namespace bindings
+     * of the larger document and avoid declaring redundant namespace URIs.
+     *
+     * <p>
+     * This is automatically done when you are marshalling to {@link XMLStreamWriter},
+     * {@link XMLEventWriter}, {@link DOMResult}, or {@link Node}, because
+     * those output format allows us to inspect what's currently available
+     * as in-scope namespace binding. However, with other output format,
+     * such as {@link OutputStream}, the JAXB RI cannot do this automatically.
+     * That's when this method comes into play.
+     *
+     * <p>
+     * Namespace bindings returned by this method will be used by the JAXB RI,
+     * but will not be re-declared. They are assumed to be available when you insert
+     * this subtree into a bigger document.
+     *
+     * <p>
+     * It is <b>NOT</b> OK to return  the same binding, or give
+     * the receiver a conflicting binding information.
+     * It's a responsibility of the caller to make sure that this doesn't happen
+     * even if the ancestor elements look like:
+     * <pre><xmp>
+     *   <foo:abc xmlns:foo="abc">
+     *     <foo:abc xmlns:foo="def">
+     *       <foo:abc xmlns:foo="abc">
+     *         ... JAXB marshalling into here.
+     *       </foo:abc>
+     *     </foo:abc>
+     *   </foo:abc>
+     * </xmp></pre>
+     *
+     * @return
+     *      always return a non-null (but possibly empty) array. The array stores
+     *      data like (prefix1,nsUri1,prefix2,nsUri2,...) Use an empty string to represent
+     *      the empty namespace URI and the default prefix. Null is not allowed as a value
+     *      in the array.
+     *
+     * @since JAXB RI 2.0 beta
+     */
+//    public String[] getContextualNamespaceDecls() {
+//        return EMPTY_STRING;
+//    }    
+    
+}

--- a/docx4j-JAXB-Glassfish/src/main/java/org/docx4j/jaxb/ri/NamespacePrefixMapperRelationshipsPart.java
+++ b/docx4j-JAXB-Glassfish/src/main/java/org/docx4j/jaxb/ri/NamespacePrefixMapperRelationshipsPart.java
@@ -1,0 +1,163 @@
+/*
+ *  Copyright 2007-2019, Plutext Pty Ltd.
+ *   
+ *  This file is part of docx4j.
+
+    docx4j is licensed under the Apache License, Version 2.0 (the "License"); 
+    you may not use this file except in compliance with the License. 
+
+    You may obtain a copy of the License at 
+
+        http://www.apache.org/licenses/LICENSE-2.0 
+
+    Unless required by applicable law or agreed to in writing, software 
+    distributed under the License is distributed on an "AS IS" BASIS, 
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+    See the License for the specific language governing permissions and 
+    limitations under the License.
+
+ */
+
+package org.docx4j.jaxb.ri;
+
+import org.docx4j.jaxb.McIgnorableNamespaceDeclarator;
+import org.docx4j.jaxb.NamespacePrefixMapperInterface;
+
+public class NamespacePrefixMapperRelationshipsPart extends com.sun.xml.bind.marshaller.NamespacePrefixMapper  implements NamespacePrefixMapperInterface, McIgnorableNamespaceDeclarator {
+	
+//	private String mcIgnorable;
+	public void setMcIgnorable(String mcIgnorable) {
+//		this.mcIgnorable = mcIgnorable;
+	}
+	
+    /**
+     * Returns a preferred prefix for the given namespace URI;
+     * this one is used *only* when we marshal the relationships part.
+     * 
+     * This method is intended to be overrided by a derived class.
+     * 
+     * @param namespaceUri
+     *      The namespace URI for which the prefix needs to be found.
+     *      Never be null. "" is used to denote the default namespace.
+     * @param suggestion
+     *      When the content tree has a suggestion for the prefix
+     *      to the given namespaceUri, that suggestion is passed as a
+     *      parameter. Typically this value comes from QName.getPrefix()
+     *      to show the preference of the content tree. This parameter
+     *      may be null, and this parameter may represent an already
+     *      occupied prefix. 
+     * @param requirePrefix
+     *      If this method is expected to return non-empty prefix.
+     *      When this flag is true, it means that the given namespace URI
+     *      cannot be set as the default namespace.
+     * 
+     * @return
+     *      null if there's no preferred prefix for the namespace URI.
+     *      In this case, the system will generate a prefix for you.
+     * 
+     *      Otherwise the system will try to use the returned prefix,
+     *      but generally there's no guarantee if the prefix will be
+     *      actually used or not.
+     * 
+     *      return "" to map this namespace URI to the default namespace.
+     *      Again, there's no guarantee that this preference will be
+     *      honored.
+     * 
+     *      If this method returns "" when requirePrefix=true, the return
+     *      value will be ignored and the system will generate one.
+     */
+    public String getPreferredPrefix(String namespaceUri, String suggestion, boolean requirePrefix) 
+    // Implement the interface    
+    {
+
+    	return getPreferredPrefixStatic( namespaceUri,  suggestion,  requirePrefix);
+    }
+    
+    protected static String getPreferredPrefixStatic(String namespaceUri, String suggestion, boolean requirePrefix) {
+    
+//    	if (namespaceUri.equals("http://schemas.openxmlformats.org/wordprocessingml/2006/main")) {
+//		return "w";
+//	}
+//	if (namespaceUri.equals("http://schemas.microsoft.com/office/2006/xmlPackage")) {
+//		return "pkg";
+//	}
+//	
+//	if (namespaceUri.equals("http://schemas.openxmlformats.org/officeDocument/2006/custom-properties")) {
+//		return "prop";
+//	}
+//	
+//	if (namespaceUri.equals("http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes")) {
+//		return "vt";
+//	}
+	    	
+	if (namespaceUri.equals("http://schemas.openxmlformats.org/package/2006/relationships")) {
+		return ""; // Make it the default namespace
+	}
+	
+//	if (namespaceUri.equals("http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing")) {
+//		return "wp";
+//	}
+//	
+//	if (namespaceUri.equals("http://schemas.openxmlformats.org/drawingml/2006/main")) {
+//		return "a";
+//	}
+//	
+//	if (namespaceUri.equals("http://schemas.openxmlformats.org/drawingml/2006/picture")) {
+//		return "pic";
+//	}
+    	
+    	return suggestion;
+    }
+    
+    /**
+     * Returns a list of namespace URIs that should be declared
+     * at the root element.
+     * <p>
+     * By default, the JAXB RI produces namespace declarations only when
+     * they are necessary, only at where they are used. Because of this
+     * lack of look-ahead, sometimes the marshaller produces a lot of
+     * namespace declarations that look redundant to human eyes. For example,
+     * <pre><xmp>
+     * <?xml version="1.0"?>
+     * <root>
+     *   <ns1:child xmlns:ns1="urn:foo"> ... </ns1:child>
+     *   <ns2:child xmlns:ns2="urn:foo"> ... </ns2:child>
+     *   <ns3:child xmlns:ns3="urn:foo"> ... </ns3:child>
+     *   ...
+     * </root>
+     * <xmp></pre>
+     * <p>
+     * If you know in advance that you are going to use a certain set of
+     * namespace URIs, you can override this method and have the marshaller
+     * declare those namespace URIs at the root element. 
+     * <p>
+     * For example, by returning <code>new String[]{"urn:foo"}</code>,
+     * the marshaller will produce:
+     * <pre><xmp>
+     * <?xml version="1.0"?>
+     * <root xmlns:ns1="urn:foo">
+     *   <ns1:child> ... </ns1:child>
+     *   <ns1:child> ... </ns1:child>
+     *   <ns1:child> ... </ns1:child>
+     *   ...
+     * </root>
+     * <xmp></pre>
+     * <p>
+     * To control prefixes assigned to those namespace URIs, use the
+     * {@link #getPreferredPrefix} method. 
+     * 
+     * @return
+     *      A list of namespace URIs as an array of {@link String}s.
+     *      This method can return a length-zero array but not null.
+     *      None of the array component can be null. To represent
+     *      the empty namespace, use the empty string <code>""</code>.
+     * 
+     * @since
+     *      JAXB RI 1.0.2 
+     */
+//    public String[] getPreDeclaredNamespaceUris() {
+//        return new String[] { "urn:abc", "urn:def" };
+//    }
+
+    
+}

--- a/docx4j-JAXB-Internal/src/main/java/org/docx4j/jaxb/generic/ContextHelperImpl.java
+++ b/docx4j-JAXB-Internal/src/main/java/org/docx4j/jaxb/generic/ContextHelperImpl.java
@@ -1,0 +1,14 @@
+package org.docx4j.jaxb.generic;
+
+import java.util.Map;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import org.docx4j.jaxb.generic.ContextHelper.ContextFactory;
+
+public class ContextHelperImpl extends ContextFactory {
+  @Override
+  JAXBContext createContext(String contextPath, ClassLoader classLoader,
+      Map<String, Object> properties) throws JAXBException {
+    return JAXBContext.newInstance(contextPath, classLoader, properties);
+  }
+}

--- a/docx4j-JAXB-Internal/src/main/java/org/docx4j/jaxb/ri/NamespacePrefixMapper.java
+++ b/docx4j-JAXB-Internal/src/main/java/org/docx4j/jaxb/ri/NamespacePrefixMapper.java
@@ -18,7 +18,7 @@
 
  */
 
-package org.docx4j.jaxb.suninternal;
+package org.docx4j.jaxb.ri;
 
 import org.docx4j.jaxb.McIgnorableNamespaceDeclarator;
 import org.docx4j.jaxb.NamespacePrefixMapperInterface;

--- a/docx4j-JAXB-Internal/src/main/java/org/docx4j/jaxb/ri/NamespacePrefixMapperRelationshipsPart.java
+++ b/docx4j-JAXB-Internal/src/main/java/org/docx4j/jaxb/ri/NamespacePrefixMapperRelationshipsPart.java
@@ -18,7 +18,7 @@
 
  */
 
-package org.docx4j.jaxb.suninternal;
+package org.docx4j.jaxb.ri;
 
 import org.docx4j.jaxb.McIgnorableNamespaceDeclarator;
 import org.docx4j.jaxb.NamespacePrefixMapperInterface;

--- a/docx4j-JAXB-MOXy/pom.xml
+++ b/docx4j-JAXB-MOXy/pom.xml
@@ -51,7 +51,7 @@
  org.eclipse.persistence.jaxb.xmlmodel;version="2.7.4"           -->              
                         </Import-Package>
                         <Export-Package>
-                            org.docx4j.jaxb.moxy
+                            org.docx4j.jaxb.moxy,org.docx4j.jaxb.generic
                         </Export-Package>
                     </instructions>
                 </configuration>

--- a/docx4j-JAXB-MOXy/src/main/java/org/docx4j/jaxb/generic/ContextHelperImpl.java
+++ b/docx4j-JAXB-MOXy/src/main/java/org/docx4j/jaxb/generic/ContextHelperImpl.java
@@ -1,0 +1,15 @@
+package org.docx4j.jaxb.generic;
+
+import java.util.Map;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import org.docx4j.jaxb.generic.ContextHelper.ContextFactory;
+
+public class ContextHelperImpl extends ContextFactory {
+
+  @Override
+  JAXBContext createContext(String contextPath, ClassLoader classLoader,
+      Map<String, Object> properties) throws JAXBException {
+    return JAXBContext.newInstance(contextPath, classLoader, properties);
+  }
+}

--- a/docx4j-JAXB-ReferenceImpl/pom.xml
+++ b/docx4j-JAXB-ReferenceImpl/pom.xml
@@ -41,7 +41,7 @@
 						</Import-Package>  
 						 -->                      
                         <Export-Package>
-                            org.docx4j.jaxb.ri
+                            org.docx4j.jaxb.ri,org.docx4j.jaxb.generic
                         </Export-Package>
                     </instructions>
                 </configuration>
@@ -72,9 +72,9 @@
 		  <groupId>org.glassfish.jaxb</groupId>
 		  <artifactId>jaxb-runtime</artifactId>
 		  <version>2.3.2</version>
-		</dependency>		
-		
-<!--  
+		</dependency>
+
+<!--
 
 	For Maven artifacts, see https://github.com/eclipse-ee4j/jaxb-ri#maven-artifacts
 	which says "In Maven projects org.glassfish.jaxb artifacts are supposed to be used"

--- a/docx4j-JAXB-ReferenceImpl/src/main/java/org/docx4j/jaxb/generic/ContextHelperImpl.java
+++ b/docx4j-JAXB-ReferenceImpl/src/main/java/org/docx4j/jaxb/generic/ContextHelperImpl.java
@@ -1,0 +1,15 @@
+package org.docx4j.jaxb.generic;
+
+import java.util.Map;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import org.docx4j.jaxb.generic.ContextHelper.ContextFactory;
+
+public class ContextHelperImpl extends ContextFactory {
+
+  @Override
+  JAXBContext createContext(String contextPath, ClassLoader classLoader,
+      Map<String, Object> properties) throws JAXBException {
+    return JAXBContext.newInstance(contextPath, classLoader, properties);
+  }
+}

--- a/docx4j-JAXB-ReferenceImpl/src/test/java/org/docx4j/jaxb/ri/MarshalTest.java
+++ b/docx4j-JAXB-ReferenceImpl/src/test/java/org/docx4j/jaxb/ri/MarshalTest.java
@@ -1,15 +1,16 @@
 package org.docx4j.jaxb.ri;
 
-import org.docx4j.XmlUtils;
-import org.docx4j.jaxb.Context;
-import org.docx4j.jaxb.NamespacePrefixMapperUtils;
-import org.docx4j.wml.P;
-import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
+import org.docx4j.XmlUtils;
+import org.docx4j.jaxb.Context;
+import org.docx4j.jaxb.NamespacePrefixMapperUtils;
+import org.docx4j.jaxb.generic.ContextHelper;
+import org.docx4j.wml.P;
+import org.junit.Test;
 
 public class MarshalTest {
 
@@ -17,7 +18,8 @@ public class MarshalTest {
 	public void JAXBImplementationTest() throws JAXBException {
 
 		java.lang.ClassLoader classLoader = NamespacePrefixMapperUtils.class.getClassLoader();
-		JAXBContext testContext = JAXBContext.newInstance("org.docx4j.relationships",classLoader );
+		JAXBContext testContext = ContextHelper
+				.createContext("org.docx4j.relationships",classLoader, null);
 		
         assertEquals("com.sun.xml.bind.v2.runtime.JAXBContextImpl", testContext.getClass().getName() );
 	}

--- a/docx4j-core/src/main/java/org/docx4j/convert/in/word2003xml/Word2003XmlConverter.java
+++ b/docx4j-core/src/main/java/org/docx4j/convert/in/word2003xml/Word2003XmlConverter.java
@@ -5,17 +5,15 @@ package org.docx4j.convert.in.word2003xml;
 
 import java.io.File;
 import java.io.IOException;
-
-import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.util.JAXBResult;
 import javax.xml.transform.Source;
 import javax.xml.transform.Templates;
 import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.stream.StreamSource;
-
 import org.apache.commons.io.FileUtils;
 import org.docx4j.XmlUtils;
+import org.docx4j.jaxb.generic.ContextHelper;
 import org.docx4j.openpackaging.exceptions.Docx4JException;
 import org.docx4j.openpackaging.exceptions.InvalidFormatException;
 import org.docx4j.openpackaging.packages.WordprocessingMLPackage;
@@ -65,7 +63,7 @@ public class Word2003XmlConverter {
 		java.lang.ClassLoader classLoader = Word2003XmlConverter.class.getClassLoader();		
 		
 		JAXBResult result = new JAXBResult(
-		         JAXBContext.newInstance("org.docx4j.convert.in.word2003xml", classLoader) );
+				ContextHelper.createContext("org.docx4j.convert.in.word2003xml", classLoader, null) );
 		XmlUtils.transform(source, xslt, null, result);
 		
 		// set the unmarshalled content tree

--- a/docx4j-core/src/main/java/org/docx4j/fonts/BestMatchingMapper.java
+++ b/docx4j-core/src/main/java/org/docx4j/fonts/BestMatchingMapper.java
@@ -24,18 +24,17 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.Unmarshaller;
-
 import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.docx4j.fonts.microsoft.MicrosoftFonts;
 import org.docx4j.fonts.substitutions.FontSubstitutions;
+import org.docx4j.jaxb.generic.ContextHelper;
 import org.docx4j.openpackaging.packages.WordprocessingMLPackage;
 import org.docx4j.openpackaging.parts.WordprocessingML.FontTablePart;
 import org.docx4j.wml.Fonts;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * 
@@ -131,7 +130,8 @@ public class BestMatchingMapper extends Mapper {
 	private final static void setupMicrosoftFontFilenames() throws Exception {
 
 		java.lang.ClassLoader classLoader = BestMatchingMapper.class.getClassLoader();				
-		JAXBContext msFontsContext = JAXBContext.newInstance("org.docx4j.fonts.microsoft", classLoader);
+		JAXBContext msFontsContext = ContextHelper
+				.createContext("org.docx4j.fonts.microsoft", classLoader, null);
 		
 		Unmarshaller u = msFontsContext.createUnmarshaller();		
 		u.setEventHandler(new org.docx4j.jaxb.JaxbValidationEventHandler());
@@ -193,7 +193,7 @@ public class BestMatchingMapper extends Mapper {
 	private final static void setupExplicitSubstitutionsMap() throws Exception {
 				
 		java.lang.ClassLoader classLoader = BestMatchingMapper.class.getClassLoader();						
-		JAXBContext substitutionsContext = JAXBContext.newInstance("org.docx4j.fonts.substitutions", classLoader);
+		JAXBContext substitutionsContext = ContextHelper.createContext("org.docx4j.fonts.substitutions", classLoader, null);
 		
 		Unmarshaller u2 = substitutionsContext.createUnmarshaller();		
 		u2.setEventHandler(new org.docx4j.jaxb.JaxbValidationEventHandler());

--- a/docx4j-core/src/main/java/org/docx4j/fonts/microsoft/MicrosoftFontsRegistry.java
+++ b/docx4j-core/src/main/java/org/docx4j/fonts/microsoft/MicrosoftFontsRegistry.java
@@ -4,10 +4,9 @@ import java.io.InputStream;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.Unmarshaller;
-
+import org.docx4j.jaxb.generic.ContextHelper;
 import org.docx4j.utils.ResourceUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,7 +44,8 @@ public class MicrosoftFontsRegistry {
 //		filenamesToMsFontNames = new HashMap<String, String>();
 		
 		java.lang.ClassLoader classLoader = MicrosoftFontsRegistry.class.getClassLoader();		
-		JAXBContext msFontsContext = JAXBContext.newInstance("org.docx4j.fonts.microsoft", classLoader);
+		JAXBContext msFontsContext = ContextHelper
+				.createContext("org.docx4j.fonts.microsoft", classLoader, null);
 		
 		Unmarshaller u = msFontsContext.createUnmarshaller();		
 		u.setEventHandler(new org.docx4j.jaxb.JaxbValidationEventHandler());

--- a/docx4j-core/src/main/java/org/docx4j/jaxb/Context.java
+++ b/docx4j-core/src/main/java/org/docx4j/jaxb/Context.java
@@ -27,12 +27,10 @@ import java.util.Enumeration;
 import java.util.jar.Attributes;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
-
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
-
 import org.apache.commons.io.IOUtils;
-import org.docx4j.utils.ResourceUtils;
+import org.docx4j.jaxb.generic.ContextHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -103,7 +101,7 @@ public class Context {
 		
       
       try { 
-			// JAXBContext.newInstance uses the context class loader of the current thread. 
+			// ContextFactory.createContext uses the context class loader of the current thread.
 			// To specify the use of a different class loader, 
 			// either set it via the Thread.setContextClassLoader() api 
 			// or use the newInstance method.
@@ -117,7 +115,7 @@ public class Context {
     	  
 			java.lang.ClassLoader classLoader = Context.class.getClassLoader();
 
-			tempContext = JAXBContext.newInstance("org.docx4j.wml:org.docx4j.w14:org.docx4j.w15:" +
+			tempContext = ContextHelper.createContext("org.docx4j.wml:org.docx4j.w14:org.docx4j.w15:" +
 					"org.docx4j.com.microsoft.schemas.office.word.x2006.wordml:" +
 					"org.docx4j.dml:org.docx4j.dml.chart:org.docx4j.dml.chart.x2007:org.docx4j.dml.chartDrawing:org.docx4j.dml.compatibility:org.docx4j.dml.diagram:org.docx4j.dml.lockedCanvas:org.docx4j.dml.picture:org.docx4j.dml.wordprocessingDrawing:org.docx4j.dml.spreadsheetdrawing:org.docx4j.dml.diagram2008:" +
 					// All VML stuff is here, since compiling it requires WML and DML (and MathML), but not PML or SML
@@ -222,21 +220,21 @@ public class Context {
 			} else {
 				log.warn("Using unexpected JAXB: " + tempContext.getClass().getName());
 			}
+
+			jcThemePart = tempContext; //ContextHelper.createContext("org.docx4j.dml",classLoader );
+			jcDocPropsCore = ContextHelper.createContext("org.docx4j.docProps.core:org.docx4j.docProps.core.dc.elements:org.docx4j.docProps.core.dc.terms",classLoader, ProviderProperties.getProviderProperties() );
+			jcDocPropsCustom = ContextHelper.createContext("org.docx4j.docProps.custom",classLoader, ProviderProperties.getProviderProperties() );
+			jcDocPropsExtended = ContextHelper.createContext("org.docx4j.docProps.extended",classLoader, ProviderProperties.getProviderProperties() );
+			jcXmlPackage = ContextHelper.createContext("org.docx4j.xmlPackage",classLoader, ProviderProperties.getProviderProperties() );
+			jcRelationships = ContextHelper.createContext("org.docx4j.relationships",classLoader, ProviderProperties.getProviderProperties() );
+			jcCustomXmlProperties = ContextHelper.createContext("org.docx4j.customXmlProperties",classLoader, ProviderProperties.getProviderProperties() );
+			jcContentTypes = ContextHelper.createContext("org.docx4j.openpackaging.contenttype",classLoader, ProviderProperties.getProviderProperties() );
 			
-			jcThemePart = tempContext; //JAXBContext.newInstance("org.docx4j.dml",classLoader );
-			jcDocPropsCore = JAXBContext.newInstance("org.docx4j.docProps.core:org.docx4j.docProps.core.dc.elements:org.docx4j.docProps.core.dc.terms",classLoader, ProviderProperties.getProviderProperties() );
-			jcDocPropsCustom = JAXBContext.newInstance("org.docx4j.docProps.custom",classLoader, ProviderProperties.getProviderProperties() );
-			jcDocPropsExtended = JAXBContext.newInstance("org.docx4j.docProps.extended",classLoader, ProviderProperties.getProviderProperties() );
-			jcXmlPackage = JAXBContext.newInstance("org.docx4j.xmlPackage",classLoader, ProviderProperties.getProviderProperties() );
-			jcRelationships = JAXBContext.newInstance("org.docx4j.relationships",classLoader, ProviderProperties.getProviderProperties() );
-			jcCustomXmlProperties = JAXBContext.newInstance("org.docx4j.customXmlProperties",classLoader, ProviderProperties.getProviderProperties() );
-			jcContentTypes = JAXBContext.newInstance("org.docx4j.openpackaging.contenttype",classLoader, ProviderProperties.getProviderProperties() );
-			
-			jcSectionModel = JAXBContext.newInstance("org.docx4j.model.structure.jaxb",classLoader, ProviderProperties.getProviderProperties() );
+			jcSectionModel = ContextHelper.createContext("org.docx4j.model.structure.jaxb",classLoader, ProviderProperties.getProviderProperties() );
 			
 			try {
-				//jcXmlDSig = JAXBContext.newInstance("org.plutext.jaxb.xmldsig",classLoader );
-				jcEncryption = JAXBContext.newInstance(
+				//jcXmlDSig = ContextHelper.createContext("org.plutext.jaxb.xmldsig",classLoader );
+				jcEncryption = ContextHelper.createContext(
 						 "org.docx4j.com.microsoft.schemas.office.x2006.encryption:"
 						+ "org.docx4j.com.microsoft.schemas.office.x2006.keyEncryptor.certificate:"
 						+ "org.docx4j.com.microsoft.schemas.office.x2006.keyEncryptor.password:"
@@ -245,7 +243,7 @@ public class Context {
 				log.error(e.getMessage());
 			}
 
-			jcMCE = JAXBContext.newInstance("org.docx4j.mce",classLoader, ProviderProperties.getProviderProperties() );
+			jcMCE = ContextHelper.createContext("org.docx4j.mce",classLoader, ProviderProperties.getProviderProperties() );
 			
 			log.debug(".. other contexts loaded ..");
 										
@@ -274,7 +272,7 @@ public class Context {
 				Context tmp = new Context();
 				java.lang.ClassLoader classLoader = tmp.getClass().getClassLoader();
 
-				jcXslFo = JAXBContext.newInstance("org.plutext.jaxb.xslfo",classLoader );
+				jcXslFo = ContextHelper.createContext("org.plutext.jaxb.xslfo",classLoader, null);
 				
 			} catch (JAXBException ex) {
 	      log.error("Cannot determine XSL-FO context", ex);

--- a/docx4j-core/src/main/java/org/docx4j/jaxb/NamespacePrefixMapperUtils.java
+++ b/docx4j-core/src/main/java/org/docx4j/jaxb/NamespacePrefixMapperUtils.java
@@ -5,12 +5,11 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.StringTokenizer;
-
 import javax.xml.XMLConstants;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
-
+import org.docx4j.jaxb.generic.ContextHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -36,7 +35,7 @@ public class NamespacePrefixMapperUtils {
 				
 		if (testContext==null) {
 			java.lang.ClassLoader classLoader = NamespacePrefixMapperUtils.class.getClassLoader();
-			testContext = JAXBContext.newInstance("org.docx4j.relationships",classLoader );
+			testContext = ContextHelper.createContext("org.docx4j.relationships",classLoader, null);
 		}
 		
 		if (testContext==null) {
@@ -57,10 +56,20 @@ public class NamespacePrefixMapperUtils {
 				throw new JAXBException("Can't create org.docx4j.jaxb.moxy.NamespacePrefixMapper", e);
 			}
 		}
-		if (testContext.getClass().getName().equals("com.sun.xml.internal.bind.v2.runtime.JAXBContextImpl")) {
-			log.info("Using com.sun.xml.internal NamespacePrefixMapper");
+    if (testContext.getClass().getName().equals("com.sun.xml.internal.bind.v2.runtime.JAXBContextImpl")) {
+      log.info("Using com.sun.xml.internal NamespacePrefixMapper");
 			try {
 				Class c = Class.forName("org.docx4j.jaxb.suninternal.NamespacePrefixMapper");
+				prefixMapper = c.newInstance();
+				return prefixMapper;
+			} catch (Exception e) {
+				throw new JAXBException("Can't create internal NamespacePrefixMapper", e);
+			}
+    }
+		if (testContext.getClass().getName().equals("com.sun.xml.bind.v2.runtime.JAXBContextImpl")) {
+			log.info("Using com.sun.xml NamespacePrefixMapper");
+			try {
+				Class c = Class.forName("org.docx4j.jaxb.ri.NamespacePrefixMapper");
 				prefixMapper = c.newInstance();
 				return prefixMapper;
 			} catch (Exception e) {
@@ -103,7 +112,7 @@ public class NamespacePrefixMapperUtils {
 
 		if (testContext==null) {
 			java.lang.ClassLoader classLoader = NamespacePrefixMapperUtils.class.getClassLoader();
-			testContext = JAXBContext.newInstance("org.docx4j.relationships",classLoader );
+			testContext = ContextHelper.createContext("org.docx4j.relationships",classLoader, null);
 		}
 		
 		if (testContext==null) {

--- a/docx4j-core/src/main/java/org/docx4j/jaxb/generic/ContextHelper.java
+++ b/docx4j-core/src/main/java/org/docx4j/jaxb/generic/ContextHelper.java
@@ -1,0 +1,28 @@
+package org.docx4j.jaxb.generic;
+
+import java.util.Map;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+
+/**
+ * Helper to make a lookup for a {@link JAXBContext}
+ */
+public class ContextHelper {
+
+  public static JAXBContext createContext(String contextPath, ClassLoader loader, Map<String,Object> properties ) throws JAXBException {
+    try {
+     ContextHelper.ContextFactory factory = (ContextFactory) Class.forName("org.docx4j.jaxb.generic.ContextHelperImpl").newInstance();
+      return factory.createContext(contextPath, loader, properties);
+    } catch (IllegalAccessException | InstantiationException | ClassNotFoundException e) {
+      throw new JAXBException("Include exactly one of the libraries docx4j-JAXB-[Internal|MOXy|ReferenceImpl|Websphere]", e);
+    }
+  }
+
+  /**
+   * Extend this class for a new way to instantiate the context.
+   */
+  public static abstract class ContextFactory {
+    abstract JAXBContext createContext(String contextPath, ClassLoader classLoader,
+        Map<String, Object> properties) throws JAXBException;
+  }
+}

--- a/docx4j-core/src/main/java/org/pptx4j/convert/out/svginhtml/SvgExporter.java
+++ b/docx4j-core/src/main/java/org/pptx4j/convert/out/svginhtml/SvgExporter.java
@@ -1,7 +1,6 @@
 package org.pptx4j.convert.out.svginhtml;
 
 import java.io.ByteArrayOutputStream;
-
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBElement;
 import javax.xml.bind.JAXBException;
@@ -10,13 +9,13 @@ import javax.xml.transform.Source;
 import javax.xml.transform.Templates;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
-
 import org.docx4j.XmlUtils;
 import org.docx4j.convert.out.AbstractConversionSettings;
 import org.docx4j.convert.out.html.HtmlCssHelper;
 import org.docx4j.dml.CTTextCharacterProperties;
 import org.docx4j.dml.CTTextParagraphProperties;
 import org.docx4j.dml.CTTransform2D;
+import org.docx4j.jaxb.generic.ContextHelper;
 import org.docx4j.model.styles.StyleTree;
 import org.docx4j.model.styles.StyleTree.AugmentedStyle;
 import org.docx4j.model.styles.Tree;
@@ -71,7 +70,8 @@ public class SvgExporter {
 	static {
 		
 		try {
-			jcSVG = JAXBContext.newInstance("org.plutext.jaxb.svg11");
+			jcSVG = ContextHelper
+					.createContext("org.plutext.jaxb.svg11", SvgExporter.class.getClassLoader(), null);
 			oFactory = new ObjectFactory();
 
 			Source xsltSource = new StreamSource(

--- a/docx4j-core/src/main/java/org/pptx4j/jaxb/Context.java
+++ b/docx4j-core/src/main/java/org/pptx4j/jaxb/Context.java
@@ -21,8 +21,8 @@ package org.pptx4j.jaxb;
 
 
 import javax.xml.bind.JAXBContext;
-
 import org.docx4j.jaxb.ProviderProperties;
+import org.docx4j.jaxb.generic.ContextHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,7 +59,7 @@ public class Context {
 			
 			java.lang.ClassLoader classLoader = Context.class.getClassLoader();
 
-			jcPML = JAXBContext.newInstance("org.pptx4j.pml:" +
+			jcPML = ContextHelper.createContext("org.pptx4j.pml:" +
 					"org.docx4j.dml:org.docx4j.dml.chart:org.docx4j.dml.chartDrawing:org.docx4j.dml.compatibility:org.docx4j.dml.diagram:org.docx4j.dml.lockedCanvas:org.docx4j.dml.picture:org.docx4j.dml.wordprocessingDrawing:org.docx4j.dml.spreadsheetdrawing:" +
 					"org.pptx4j.com.microsoft.schemas.office.powerpoint.x2010.main:" +
 					"org.pptx4j.com.microsoft.schemas.office.powerpoint.x2012.main:" +

--- a/docx4j-core/src/main/java/org/xlsx4j/jaxb/Context.java
+++ b/docx4j-core/src/main/java/org/xlsx4j/jaxb/Context.java
@@ -21,8 +21,8 @@ package org.xlsx4j.jaxb;
 
 
 import javax.xml.bind.JAXBContext;
-
 import org.docx4j.jaxb.ProviderProperties;
+import org.docx4j.jaxb.generic.ContextHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -58,7 +58,7 @@ public class Context {
 			
 			java.lang.ClassLoader classLoader = Context.class.getClassLoader();
 				
-			jcSML = JAXBContext.newInstance("org.xlsx4j.sml:" +
+			jcSML = ContextHelper.createContext("org.xlsx4j.sml:" +
 					"org.xlsx4j.schemas.microsoft.com.office.excel.x2010.spreadsheetDrawing:" +	
 					"org.xlsx4j.schemas.microsoft.com.office.excel_2006.main:" +
 					"org.xlsx4j.schemas.microsoft.com.office.excel_2008_2.main",classLoader, ProviderProperties.getProviderProperties() );

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,8 @@
         
         <module>docx4j-JAXB-MOXy</module>
         <module>docx4j-JAXB-ReferenceImpl</module>
-        
+        <module>docx4j-JAXB-Glassfish</module>
+
         <module>docx4j-samples-resources</module>
         <module>docx4j-samples-docx4j</module>
         <module>docx4j-samples-docx-diffx</module>


### PR DESCRIPTION
Based on https://github.com/plutext/docx4j/pull/411 but a more generic approach to fix Docx4j on Websphere Liberty.
Generic approach with new module that bundles the glassfish reference implementation and uses it hardwired.