### PR TITLE
fix bug about Chinese characters in language selection

### DIFF
--- a/docx4j-core/src/main/java/org/docx4j/fonts/LanguageTagToScriptMapping.java
+++ b/docx4j-core/src/main/java/org/docx4j/fonts/LanguageTagToScriptMapping.java
@@ -75,8 +75,8 @@ public class LanguageTagToScriptMapping {
 		if (lang.equals("zh")) {
 		
 			//    <a:font script="Hans" typeface="宋体"/>
-			if (langTag.equals("zh_CN")
-					|| langTag.equals("zh_SG")) {
+			if (langTag.equals("zh-CN")
+					|| langTag.equals("zh-SG")) {
 				// Mainland China and Singapore both use simplified characters
 				return "Hans";
 			} else {


### PR DESCRIPTION
when get lang by langtag, use the '-' to split, but when lang equals “zh”, it was judged by '_', so it nerver choose "hans" script