### PR TITLE
make it possible to turn off automatic deletion of temporary font files

### DIFF
--- a/docx4j-core/src/main/java/org/docx4j/openpackaging/parts/AbstractFontPart.java
+++ b/docx4j-core/src/main/java/org/docx4j/openpackaging/parts/AbstractFontPart.java
@@ -51,6 +51,8 @@ public abstract class AbstractFontPart extends BinaryPart {
 	public static File getTmpFontDir() {
 		return tmpFontDir;
 	}
+
+	protected static boolean deleteFileOnFinalize;
     
     static {
     	
@@ -80,7 +82,10 @@ public abstract class AbstractFontPart extends BinaryPart {
             }
     	
     	}
-    }
+
+		deleteFileOnFinalize = Docx4jProperties.getProperty(
+				"docx4j.openpackaging.parts.WordprocessingML.ObfuscatedFontPart.deleteFileOnFinalize", true);
+	}
     
     public static String getTemporaryEmbeddedFontsDir() {
     	
@@ -141,7 +146,7 @@ public abstract class AbstractFontPart extends BinaryPart {
 	protected void finalize() throws Throwable {
 		
         try {
-        	if (getF()!=null) {
+        	if (deleteFileOnFinalize && getF()!=null) {
 	    		log.debug("Deleting  " + getF().getName());
 				getF().delete();
         	}

--- a/docx4j-core/src/main/java/org/docx4j/openpackaging/parts/WordprocessingML/ObfuscatedFontPart.java
+++ b/docx4j-core/src/main/java/org/docx4j/openpackaging/parts/WordprocessingML/ObfuscatedFontPart.java
@@ -241,7 +241,7 @@ public class ObfuscatedFontPart extends AbstractFontPart {
 	protected void finalize() throws Throwable {
 		
         try {
-        	if (getF()!=null) {
+        	if (deleteFileOnFinalize && getF()!=null) {
 	    		log.debug("Deleting  " + getF().getName());
 				getF().delete();
         	}

--- a/docx4j-samples-resources/src/main/resources/docx4j.properties
+++ b/docx4j-samples-resources/src/main/resources/docx4j.properties
@@ -253,6 +253,10 @@ docx4j.openpackaging.parts.WordprocessingML.NumberingDefinitionsPart.DefaultNumb
 # (creating it if necessary).
 #docx4j.openpackaging.parts.WordprocessingML.ObfuscatedFontPart.tmpFontDir=c:\\temp
 
+# Embedded Fonts - deletion on finalize
+# By default, docx4j will delete temporary fonts in finalize.
+#docx4j.openpackaging.parts.WordprocessingML.ObfuscatedFontPart.deleteFileOnFinalize=false
+
 
 # OpenDoPE
 


### PR DESCRIPTION
- Makes it possible to solve https://github.com/plutext/docx4j/issues/441 without using custom code.