### PR TITLE
GC is performed only if the temporary file is not successfully deleted

### DIFF
--- a/docx4j-core/src/main/java/org/docx4j/openpackaging/parts/WordprocessingML/BinaryPartAbstractImage.java
+++ b/docx4j-core/src/main/java/org/docx4j/openpackaging/parts/WordprocessingML/BinaryPartAbstractImage.java
@@ -306,16 +306,17 @@ public abstract class BinaryPartAbstractImage extends BinaryPart {
 		// Also reported on Win XP, but in my testing, the files were deleting OK anyway.
 		fos = null;
 		fis = null;
-		if (Docx4jProperties.getProperty("docx4j.openpackaging.parts.WordprocessingML.BinaryPartAbstractImage.TempFiles.ForceGC", true)) {
+		tmpImageFile.delete();
+		if (Docx4jProperties.getProperty("docx4j.openpackaging.parts.WordprocessingML.BinaryPartAbstractImage.TempFiles.ForceGC", true) && tmpImageFile.exists()) {
 			System.gc();
-		}
-        if (tmpImageFile.delete()) {
-            log.debug(".. deleted " + tmpImageFile.getAbsolutePath());
-		} else {
-			log.warn("Couldn't delete tmp file " + tmpImageFile.getAbsolutePath());
-			tmpImageFile.deleteOnExit();
-			// If that doesn't work, see "Clean Up Your Mess: Managing Temp Files in Java Apps"
-			// at devx.com
+			if (tmpImageFile.delete()) {
+				log.debug(".. deleted " + tmpImageFile.getAbsolutePath());
+			} else {
+				log.warn("Couldn't delete tmp file " + tmpImageFile.getAbsolutePath());
+				tmpImageFile.deleteOnExit();
+				// If that doesn't work, see "Clean Up Your Mess: Managing Temp Files in Java Apps"
+				// at devx.com
+			}
 		}
 		
 		return imagePart;


### PR DESCRIPTION
GC is performed only if the temporary file is not successfully deleted Performing GC every time has a great impact on performance