### PR TITLE
Add chinese numbering support (include decimal enclosed circle)

### DIFF
--- a/docx4j-core/src/main/java/org/docx4j/model/listnumbering/ListLevel.java
+++ b/docx4j-core/src/main/java/org/docx4j/model/listnumbering/ListLevel.java
@@ -341,6 +341,25 @@ public class ListLevel {
     		NumberFormatDecimalZero converter = new NumberFormatDecimalZero(); 
     		return converter.format(current);
     	}
+        // These two are the same in Chinese
+        // no need to be processed separately
+    	if (numFmt.equals( NumberFormat.CHINESE_COUNTING ) ||
+                numFmt.equals( NumberFormat.CHINESE_COUNTING_THOUSAND ) ) {
+    		NumberFormatChineseLower converter = new NumberFormatChineseLower();
+    		return converter.format(current);
+    	}
+        // This one means use upper Chinese number characters
+        if (numFmt.equals( NumberFormat.CHINESE_LEGAL_SIMPLIFIED ) ) {
+            NumberFormatChineseUpper converter = new NumberFormatChineseUpper();
+            return converter.format(current);
+        }
+        // These two are the same
+        // just to adapt to documents in Chinese
+        if (numFmt.equals( NumberFormat.DECIMAL_ENCLOSED_CIRCLE ) ||
+                numFmt.equals( NumberFormat.DECIMAL_ENCLOSED_CIRCLE_CHINESE )) {
+            NumberFormatDecimalEnclosedCircle converter = new NumberFormatDecimalEnclosedCircle();
+            return converter.format(current);
+        }
     	
     	log.error("Unhandled numFmt: " + numFmt.name() );
         return this.counter.getCurrentValue().toString();

--- a/docx4j-core/src/main/java/org/docx4j/model/listnumbering/NumberFormatChineseAbstract.java
+++ b/docx4j-core/src/main/java/org/docx4j/model/listnumbering/NumberFormatChineseAbstract.java
@@ -1,0 +1,70 @@
+package org.docx4j.model.listnumbering;
+
+public class NumberFormatChineseAbstract extends NumberFormat {
+
+    String[] CHINESE_NUMBER_CHARACTERS;
+    String[] CHINESE_NUMBER_UNITS;
+    String[] CHINESE_NUMBER_BIG_UNITS;
+
+    @Override
+    public String format(int in) {
+        if (in == 0) {
+            return CHINESE_NUMBER_CHARACTERS[0];
+        }
+
+        StringBuilder chineseStr = new StringBuilder();
+        int bigUnitPosition = 0;
+        boolean lastIsZero = false;
+
+        while (in > 0) {
+            // Process four digits each time
+            int part = in % 10000;
+            if (part != 0) {
+                String partStr = convertFourDigit(part);
+                if (bigUnitPosition > 0) {
+                    chineseStr.insert(0, CHINESE_NUMBER_BIG_UNITS[bigUnitPosition]);
+                }
+                chineseStr.insert(0, partStr);
+                lastIsZero = false;
+            } else if (!lastIsZero && chineseStr.length() > 0) {
+                chineseStr.insert(0, CHINESE_NUMBER_CHARACTERS[0]);
+                lastIsZero = true;
+            }
+
+            in /= 10000;
+            bigUnitPosition++;
+        }
+
+        return chineseStr.toString();
+    }
+
+    /**
+     * Convert parts below four digits
+     */
+    private String convertFourDigit(int num) {
+        StringBuilder partStr = new StringBuilder();
+        int unitPosition = 0;
+        boolean lastIsZero = false;
+
+        while (num > 0) {
+            int digit = num % 10;
+            if (digit != 0) {
+                partStr.insert(0, CHINESE_NUMBER_UNITS[unitPosition]);
+                partStr.insert(0, CHINESE_NUMBER_CHARACTERS[digit]);
+                lastIsZero = false;
+            } else if (!lastIsZero) {
+                partStr.insert(0, CHINESE_NUMBER_CHARACTERS[0]);
+                lastIsZero = true;
+            }
+            num /= 10;
+            unitPosition++;
+        }
+
+        // Remove the last "零"
+        if (partStr.charAt(partStr.length() - 1) == '零') {
+            partStr.deleteCharAt(partStr.length() - 1);
+        }
+
+        return partStr.toString();
+    }
+}

--- a/docx4j-core/src/main/java/org/docx4j/model/listnumbering/NumberFormatChineseLower.java
+++ b/docx4j-core/src/main/java/org/docx4j/model/listnumbering/NumberFormatChineseLower.java
@@ -1,0 +1,9 @@
+package org.docx4j.model.listnumbering;
+
+public class NumberFormatChineseLower extends NumberFormatChineseAbstract {
+    NumberFormatChineseLower() {
+        CHINESE_NUMBER_CHARACTERS = new String[]{"零", "一", "二", "三", "四", "五", "六", "七", "八", "九"};
+        CHINESE_NUMBER_UNITS = new String[]{"", "十", "百", "千"};
+        CHINESE_NUMBER_BIG_UNITS = new String[]{"", "万", "亿"};
+    }
+}

--- a/docx4j-core/src/main/java/org/docx4j/model/listnumbering/NumberFormatChineseUpper.java
+++ b/docx4j-core/src/main/java/org/docx4j/model/listnumbering/NumberFormatChineseUpper.java
@@ -1,0 +1,9 @@
+package org.docx4j.model.listnumbering;
+
+public class NumberFormatChineseUpper extends NumberFormatChineseAbstract {
+    NumberFormatChineseUpper() {
+        CHINESE_NUMBER_CHARACTERS = new String[]{"零", "壹", "贰", "叁", "肆", "伍", "陆", "柒", "捌", "玖"};
+        CHINESE_NUMBER_UNITS = new String[]{"", "拾", "佰", "仟"};
+        CHINESE_NUMBER_BIG_UNITS = new String[]{"", "万", "亿"};
+    }
+}

--- a/docx4j-core/src/main/java/org/docx4j/model/listnumbering/NumberFormatDecimalEnclosedCircle.java
+++ b/docx4j-core/src/main/java/org/docx4j/model/listnumbering/NumberFormatDecimalEnclosedCircle.java
@@ -1,0 +1,14 @@
+package org.docx4j.model.listnumbering;
+
+public class NumberFormatDecimalEnclosedCircle extends NumberFormat {
+    String[] DECIMAL_ENCLOSED_CIRCLE_CHARACTERS = {"①", "②", "③", "④", "⑤", "⑥", "⑦", "⑧", "⑨", "⑩",
+            "⑪", "⑫", "⑬", "⑭", "⑮", "⑯", "⑰", "⑱", "⑲", "⑳"};
+
+    @Override
+    public String format(int in) {
+        if (in <= 0 || in > 20) {
+            throw new NumberFormatException("Numbers must be in range 1-20");
+        }
+        return DECIMAL_ENCLOSED_CIRCLE_CHARACTERS[in - 1];
+    }
+}


### PR DESCRIPTION
Chinese numbering formats are not supported, and this PR has added four classes to support them.
It should cover most Chinese documents.
and from my understanding, this PR should also be able to be merged into VERSION_11+ to support Chinese numbering formats.