### PR TITLE
Further support for w:jc/w:val = start and end

### DIFF
--- a/docx4j-openxml-objects/src/main/java/org/docx4j/wml/JcEnumeration.java
+++ b/docx4j-openxml-objects/src/main/java/org/docx4j/wml/JcEnumeration.java
@@ -38,6 +38,8 @@ import jakarta.xml.bind.annotation.XmlType;
  *     &lt;enumeration value="center"/>
  *     &lt;enumeration value="right"/>
  *     &lt;enumeration value="both"/>
+ *     &lt;enumeration value="start"/>
+ *     &lt;enumeration value="end"/>
  *     &lt;enumeration value="mediumKashida"/>
  *     &lt;enumeration value="distribute"/>
  *     &lt;enumeration value="numTab"/>
@@ -82,6 +84,21 @@ public enum JcEnumeration {
     @XmlEnumValue("both")
     BOTH("both"),
 
+    /**
+     * Align to the start of the line.
+     * 
+     */
+    @XmlEnumValue("start")
+    START("start"),
+
+    /**
+     * Align to the end of the line.
+     * 
+     */
+    @XmlEnumValue("end")
+    END("end"),
+
+    
     /**
      * Medium Kashida Length
      * 


### PR DESCRIPTION
Loading a docx file in docx4j with a justification style (w:jc/w:val) set to the values "start" or "end" results in the w:val attributes being removed in styles.xml, which MS Word treats as an error on startup.  
Adding them to JcEnumeration is enough to fix.

