### PR TITLE
docx4j-core 11.5.3 :: Fixed wrong Generic type for ExternalLinkPart

### DIFF
--- a/docx4j-core/src/main/java/org/docx4j/openpackaging/parts/SpreadsheetML/ExternalLinkPart.java
+++ b/docx4j-core/src/main/java/org/docx4j/openpackaging/parts/SpreadsheetML/ExternalLinkPart.java
@@ -1,13 +1,11 @@
 package org.docx4j.openpackaging.parts.SpreadsheetML;
 
-import jakarta.xml.bind.JAXBElement;
-
 import org.docx4j.openpackaging.exceptions.InvalidFormatException;
 import org.docx4j.openpackaging.parts.PartName;
 import org.docx4j.openpackaging.parts.relationships.Namespaces;
 import org.xlsx4j.sml.CTExternalLink;
 
-public class ExternalLinkPart  extends JaxbSmlPart<JAXBElement<CTExternalLink>> {
+public class ExternalLinkPart  extends JaxbSmlPart<CTExternalLink> {
 	
 	
 	public ExternalLinkPart(PartName partName) throws InvalidFormatException {


### PR DESCRIPTION
Hi there!
Here is the simple fix for https://github.com/plutext/docx4j/issues/613