### PR TITLE
Support for start and end instead of left and right in table borders.

### DIFF
--- a/docx4j-openxml-objects/src/main/java/org/docx4j/wml/CTTblCellMar.java
+++ b/docx4j-openxml-objects/src/main/java/org/docx4j/wml/CTTblCellMar.java
@@ -42,8 +42,10 @@ import org.jvnet.jaxb2_commons.ppp.Child;
  *       &lt;sequence>
  *         &lt;element name="top" type="{http://schemas.openxmlformats.org/wordprocessingml/2006/main}CT_TblWidth" minOccurs="0"/>
  *         &lt;element name="left" type="{http://schemas.openxmlformats.org/wordprocessingml/2006/main}CT_TblWidth" minOccurs="0"/>
+ *         &lt;element name="start" type="{http://schemas.openxmlformats.org/wordprocessingml/2006/main}CT_TblWidth" minOccurs="0"/>
  *         &lt;element name="bottom" type="{http://schemas.openxmlformats.org/wordprocessingml/2006/main}CT_TblWidth" minOccurs="0"/>
  *         &lt;element name="right" type="{http://schemas.openxmlformats.org/wordprocessingml/2006/main}CT_TblWidth" minOccurs="0"/>
+ *         &lt;element name="end" type="{http://schemas.openxmlformats.org/wordprocessingml/2006/main}CT_TblWidth" minOccurs="0"/>
  *       &lt;/sequence>
  *     &lt;/restriction>
  *   &lt;/complexContent>
@@ -56,16 +58,20 @@ import org.jvnet.jaxb2_commons.ppp.Child;
 @XmlType(name = "CT_TblCellMar", propOrder = {
     "top",
     "left",
+    "start",
     "bottom",
-    "right"
+    "right",
+    "end"
 })
 public class CTTblCellMar implements Child
 {
 
     protected TblWidth top;
     protected TblWidth left;
+    protected TblWidth start;
     protected TblWidth bottom;
     protected TblWidth right;
+    protected TblWidth end;
     @XmlTransient
     private Object parent;
 
@@ -116,6 +122,30 @@ public class CTTblCellMar implements Child
     public void setLeft(TblWidth value) {
         this.left = value;
     }
+    
+    /**
+     * Gets the value of the start property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link TblWidth }
+     *     
+     */
+    public TblWidth getStart() {
+        return start;
+    }
+
+    /**
+     * Sets the value of the start property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link TblWidth }
+     *     
+     */
+    public void setStart(TblWidth value) {
+        this.start = value;
+    }
 
     /**
      * Gets the value of the bottom property.
@@ -163,6 +193,30 @@ public class CTTblCellMar implements Child
      */
     public void setRight(TblWidth value) {
         this.right = value;
+    }
+
+    /**
+     * Gets the value of the end property.
+     * 
+     * @return
+     *     possible object is
+     *     {@link TblWidth }
+     *     
+     */
+    public TblWidth getEnd() {
+        return end;
+    }
+
+    /**
+     * Sets the value of the end property.
+     * 
+     * @param value
+     *     allowed object is
+     *     {@link TblWidth }
+     *     
+     */
+    public void setEnd(TblWidth value) {
+        this.end = value;
     }
 
     /**

--- a/docx4j-openxml-objects/src/main/java/org/docx4j/wml/TcPrInner.java
+++ b/docx4j-openxml-objects/src/main/java/org/docx4j/wml/TcPrInner.java
@@ -99,8 +99,10 @@ import org.jvnet.jaxb2_commons.ppp.Child;
  *                 &lt;sequence>
  *                   &lt;element name="top" type="{http://schemas.openxmlformats.org/wordprocessingml/2006/main}CT_Border" minOccurs="0"/>
  *                   &lt;element name="left" type="{http://schemas.openxmlformats.org/wordprocessingml/2006/main}CT_Border" minOccurs="0"/>
+ *                   &lt;element name="start" type="{http://schemas.openxmlformats.org/wordprocessingml/2006/main}CT_Border" minOccurs="0"/>
  *                   &lt;element name="bottom" type="{http://schemas.openxmlformats.org/wordprocessingml/2006/main}CT_Border" minOccurs="0"/>
  *                   &lt;element name="right" type="{http://schemas.openxmlformats.org/wordprocessingml/2006/main}CT_Border" minOccurs="0"/>
+ *                   &lt;element name="end" type="{http://schemas.openxmlformats.org/wordprocessingml/2006/main}CT_Border" minOccurs="0"/>
  *                   &lt;element name="insideH" type="{http://schemas.openxmlformats.org/wordprocessingml/2006/main}CT_Border" minOccurs="0"/>
  *                   &lt;element name="insideV" type="{http://schemas.openxmlformats.org/wordprocessingml/2006/main}CT_Border" minOccurs="0"/>
  *                   &lt;element name="tl2br" type="{http://schemas.openxmlformats.org/wordprocessingml/2006/main}CT_Border" minOccurs="0"/>
@@ -762,8 +764,10 @@ public class TcPrInner implements Child
      *       &lt;sequence>
      *         &lt;element name="top" type="{http://schemas.openxmlformats.org/wordprocessingml/2006/main}CT_Border" minOccurs="0"/>
      *         &lt;element name="left" type="{http://schemas.openxmlformats.org/wordprocessingml/2006/main}CT_Border" minOccurs="0"/>
+	 *         &lt;element name="start" type="{http://schemas.openxmlformats.org/wordprocessingml/2006/main}CT_Border" minOccurs="0"/>
      *         &lt;element name="bottom" type="{http://schemas.openxmlformats.org/wordprocessingml/2006/main}CT_Border" minOccurs="0"/>
      *         &lt;element name="right" type="{http://schemas.openxmlformats.org/wordprocessingml/2006/main}CT_Border" minOccurs="0"/>
+	 *         &lt;element name="end" type="{http://schemas.openxmlformats.org/wordprocessingml/2006/main}CT_Border" minOccurs="0"/>
      *         &lt;element name="insideH" type="{http://schemas.openxmlformats.org/wordprocessingml/2006/main}CT_Border" minOccurs="0"/>
      *         &lt;element name="insideV" type="{http://schemas.openxmlformats.org/wordprocessingml/2006/main}CT_Border" minOccurs="0"/>
      *         &lt;element name="tl2br" type="{http://schemas.openxmlformats.org/wordprocessingml/2006/main}CT_Border" minOccurs="0"/>
@@ -780,8 +784,10 @@ public class TcPrInner implements Child
     @XmlType(name = "", propOrder = {
         "top",
         "left",
+		"start",
         "bottom",
         "right",
+		"end",
         "insideH",
         "insideV",
         "tl2Br",
@@ -792,8 +798,10 @@ public class TcPrInner implements Child
 
         protected CTBorder top;
         protected CTBorder left;
+		protected CTBorder start;
         protected CTBorder bottom;
         protected CTBorder right;
+		protected CTBorder end;
         protected CTBorder insideH;
         protected CTBorder insideV;
         @XmlElement(name = "tl2br")
@@ -850,7 +858,31 @@ public class TcPrInner implements Child
         public void setLeft(CTBorder value) {
             this.left = value;
         }
+		
+        /**
+         * Gets the value of the start property.
+         * 
+         * @return
+         *     possible object is
+         *     {@link CTBorder }
+         *     
+         */
+        public CTBorder getStart() {
+            return start;
+        }
 
+        /**
+         * Sets the value of the start property.
+         * 
+         * @param value
+         *     allowed object is
+         *     {@link CTBorder }
+         *     
+         */
+        public void setStart(CTBorder value) {
+            this.start = value;
+        }
+		
         /**
          * Gets the value of the bottom property.
          * 
@@ -899,6 +931,30 @@ public class TcPrInner implements Child
             this.right = value;
         }
 
+        /**
+         * Gets the value of the end property.
+         * 
+         * @return
+         *     possible object is
+         *     {@link CTBorder }
+         *     
+         */
+        public CTBorder getEnd() {
+            return end;
+        }
+
+        /**
+         * Sets the value of the end property.
+         * 
+         * @param value
+         *     allowed object is
+         *     {@link CTBorder }
+         *     
+         */
+        public void setEnd(CTBorder value) {
+            this.end = value;
+        }
+		
         /**
          * Gets the value of the insideH property.
          * 


### PR DESCRIPTION
Hello,

If you create a table with some borders using LibreOffice (I'm on 25.2.5.1) it will have "w:start" and "w:end" (where previous versions used "w:left" and "w:right") under w:tbl/w:tblPr/w:tblCellMar and w:tbl/w:tr/w:tc/w:tcPrc/w:tcBorders.

Docx4J ignores those lines (I assume because the XML parser doesn't know what to do with them, same as [the other one](https://github.com/plutext/docx4j/pull/608) ) and so this change adds that support.
