### PR TITLE
Fix #668: setWordCompatSetting only set value if no previous value set

### DIFF
--- a/docx4j-core/src/main/java/org/docx4j/openpackaging/parts/WordprocessingML/DocumentSettingsPart.java
+++ b/docx4j-core/src/main/java/org/docx4j/openpackaging/parts/WordprocessingML/DocumentSettingsPart.java
@@ -172,9 +172,9 @@ public final class DocumentSettingsPart extends JaxbXmlPartXPathAware<CTSettings
 		CTCompat compat = this.getJaxbElement().getCompat();
 		if (compat==null) {
 			log.debug("No w:settings/w:compat element; creating..");
+			compat = Context.getWmlObjectFactory().createCTCompat();
+			this.getJaxbElement().setCompat(compat);
 		}
-		compat = Context.getWmlObjectFactory().createCTCompat();
-		this.getJaxbElement().setCompat(compat);
 		
 		CTCompatSetting theSetting = null;
 		for (CTCompatSetting setting : compat.getCompatSetting() ) {


### PR DESCRIPTION
Previous value must be kept if it is a non-null value, only set new value if no previous value (= null value) available.