### PR TITLE
Guard list content appends against null list state

### DIFF
--- a/docx4j-core/src/main/java/org/docx4j/convert/out/html/ListsToContentControls.java
+++ b/docx4j-core/src/main/java/org/docx4j/convert/out/html/ListsToContentControls.java
@@ -388,7 +388,11 @@ public class ListsToContentControls {
 						listStack.push(listSpec);
 					}
 					
-					listSpec.sdtList.getSdtContent().getContent().add(paragraph);
+					if (listSpec != null && listSpec.sdtList != null && listSpec.sdtList.getSdtContent() != null) {
+						listSpec.sdtList.getSdtContent().getContent().add(paragraph);
+					} else {
+						resultElts.add(unwrapped);
+					}
 				} else if (numId==null) {
 					log.error("TODO: encountered null numId!");
 					closeAllLists();
@@ -434,7 +438,11 @@ public class ListsToContentControls {
 						}
 						
 					}
-					listSpec.sdtList.getSdtContent().getContent().add(paragraph);										
+					if (listSpec != null && listSpec.sdtList != null && listSpec.sdtList.getSdtContent() != null) {
+						listSpec.sdtList.getSdtContent().getContent().add(paragraph);
+					} else {
+						resultElts.add(unwrapped);
+					}									
 				} 
 				
 				


### PR DESCRIPTION
Add null checks before appending paragraphs to generated list content controls in ListsToContentControls.

When list state is missing or incomplete, keep the original paragraph in the result instead of dereferencing sdtList or sdtContent. This prevents NullPointerException in copied list conversion logic without changing the normal list-building flow.

Caused by: java.lang.NullPointerException: Cannot read field "sdtList" because "listSpec" is null
	at org.docx4j.convert.out.html.ListsToContentControls.groupContent(ListsToContentControls.java:391)
	at org.docx4j.convert.out.html.ListsToContentControls.process(ListsToContentControls.java:154)
	at org.docx4j.convert.out.html.ListsToContentControls.process(ListsToContentControls.java:114)
	at org.docx4j.convert.out.common.Preprocess.process(Preprocess.java:172)
	at org.docx4j.convert.out.common.AbstractWmlExporter.preprocess(AbstractWmlExporter.java:70)
	at org.docx4j.convert.out.common.AbstractWmlExporter.preprocess(AbstractWmlExporter.java:32)
	at org.docx4j.convert.out.common.AbstractExporter.export(AbstractExporter.java:64)
	... 51 common frames omitted