### PR TITLE
Handle missing numbering level values safely, NPE in ListLevel.java

### DIFF
--- a/docx4j-core-tests/src/test/java/org/docx4j/model/listnumbering/NumberingLevelNullSafetyTest.java
+++ b/docx4j-core-tests/src/test/java/org/docx4j/model/listnumbering/NumberingLevelNullSafetyTest.java
@@ -1,0 +1,85 @@
+package org.docx4j.model.listnumbering;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+import java.math.BigInteger;
+
+import org.docx4j.wml.Lvl;
+import org.docx4j.wml.Numbering;
+import org.docx4j.wml.PPrBase.NumPr;
+import org.junit.Test;
+
+public class NumberingLevelNullSafetyTest {
+
+	@Test
+	public void directListLevelConstructionDefaultsMissingIdToZero() {
+		Lvl level = new Lvl();
+
+		ListLevel listLevel = new ListLevel(level);
+
+		assertEquals(BigInteger.ZERO, level.getIlvl());
+		assertEquals("0", listLevel.getID());
+	}
+
+	@Test
+	public void missingAbstractLevelIdUsesFirstAvailableLevel() {
+		Numbering.AbstractNum abstractNum = new Numbering.AbstractNum();
+		abstractNum.setAbstractNumId(BigInteger.ZERO);
+
+		Lvl missingLevelId = new Lvl();
+		Lvl levelZero = new Lvl();
+		levelZero.setIlvl(BigInteger.ZERO);
+		abstractNum.getLvl().add(missingLevelId);
+		abstractNum.getLvl().add(levelZero);
+
+		AbstractListNumberingDefinition definition = new AbstractListNumberingDefinition(abstractNum);
+
+		assertEquals(BigInteger.ONE, missingLevelId.getIlvl());
+		assertSame(missingLevelId, definition.getListLevels().get("1").getJaxbAbstractLvl());
+		assertSame(levelZero, definition.getListLevels().get("0").getJaxbAbstractLvl());
+	}
+
+	@Test
+	public void linkedStyleLevelDoesNotOverwriteExistingLevel() {
+		Numbering.AbstractNum abstractNum = new Numbering.AbstractNum();
+		abstractNum.setAbstractNumId(BigInteger.ZERO);
+		Numbering.AbstractNum.NumStyleLink numStyleLink = new Numbering.AbstractNum.NumStyleLink();
+		numStyleLink.setVal("LinkedListStyle");
+		abstractNum.setNumStyleLink(numStyleLink);
+
+		Lvl levelZero = new Lvl();
+		levelZero.setIlvl(BigInteger.ZERO);
+		abstractNum.getLvl().add(levelZero);
+
+		AbstractListNumberingDefinition definition = new AbstractListNumberingDefinition(abstractNum);
+		Numbering.AbstractNum linkedAbstractNum = new Numbering.AbstractNum();
+		linkedAbstractNum.setAbstractNumId(BigInteger.ONE);
+		Lvl linkedLevelWithoutId = new Lvl();
+		linkedAbstractNum.getLvl().add(linkedLevelWithoutId);
+
+		definition.updateDefinitionFromLinkedStyle(linkedAbstractNum);
+
+		assertEquals(BigInteger.ONE, linkedLevelWithoutId.getIlvl());
+		assertSame(levelZero, definition.getListLevels().get("0").getJaxbAbstractLvl());
+		assertSame(linkedLevelWithoutId, definition.getListLevels().get("1").getJaxbAbstractLvl());
+	}
+
+	@Test
+	public void missingParagraphLevelDefaultsToZero() {
+		NumPr numPr = new NumPr();
+
+		assertNull(Emulator.getExplicitIlvl(numPr));
+		assertEquals(BigInteger.ZERO, Emulator.getIlvlOrDefault(numPr));
+	}
+
+	@Test
+	public void paragraphLevelWithoutValueDefaultsToZero() {
+		NumPr numPr = new NumPr();
+		numPr.setIlvl(new NumPr.Ilvl());
+
+		assertNull(Emulator.getExplicitIlvl(numPr));
+		assertEquals(BigInteger.ZERO, Emulator.getIlvlOrDefault(numPr));
+	}
+}

--- a/docx4j-core/src/main/java/org/docx4j/convert/out/html/HTMLExporterVisitorGenerator.java
+++ b/docx4j-core/src/main/java/org/docx4j/convert/out/html/HTMLExporterVisitorGenerator.java
@@ -19,6 +19,8 @@
  */
 package org.docx4j.convert.out.html;
 
+import java.math.BigInteger;
+
 import org.docx4j.convert.out.common.AbstractVisitorExporterDelegate;
 import org.docx4j.convert.out.common.AbstractVisitorExporterDelegate.AbstractVisitorExporterGeneratorFactory;
 import org.docx4j.convert.out.common.AbstractVisitorExporterGenerator;
@@ -115,7 +117,8 @@ public class HTMLExporterVisitorGenerator extends AbstractVisitorExporterGenerat
 			String levelId=null;
 			if (pPrDirect.getNumPr()!=null) {
 				numId = pPrDirect.getNumPr().getNumId()==null ? null : pPrDirect.getNumPr().getNumId().getVal().toString(); 
-				levelId = pPrDirect.getNumPr().getIlvl()==null ? null : pPrDirect.getNumPr().getIlvl().getVal().toString(); 
+				BigInteger explicitIlvl = org.docx4j.model.listnumbering.Emulator.getExplicitIlvl(pPrDirect.getNumPr());
+				levelId = explicitIlvl == null ? null : explicitIlvl.toString();
 			}
 			
         	ResultTriple triple = org.docx4j.model.listnumbering.Emulator.getNumber(

--- a/docx4j-core/src/main/java/org/docx4j/convert/out/html/ListsToContentControls.java
+++ b/docx4j-core/src/main/java/org/docx4j/convert/out/html/ListsToContentControls.java
@@ -12,6 +12,7 @@ import org.docx4j.finders.SdtFinder;
 import org.docx4j.finders.TcFinder;
 import org.docx4j.model.PropertyResolver;
 import org.docx4j.model.listnumbering.AbstractListNumberingDefinition;
+import org.docx4j.model.listnumbering.Emulator;
 import org.docx4j.model.listnumbering.ListLevel;
 import org.docx4j.model.listnumbering.ListNumberingDefinition;
 import org.docx4j.openpackaging.exceptions.CyclicStylesException;
@@ -349,12 +350,7 @@ public class ListsToContentControls {
 				
 				BigInteger numId = numPr.getNumId().getVal();
 				
-				BigInteger ilvl = null;
-				if (numPr.getIlvl()==null) {
-					ilvl = BigInteger.ZERO;
-				} else {
-					ilvl = numPr.getIlvl().getVal();
-				}
+				BigInteger ilvl = Emulator.getIlvlOrDefault(numPr);
 				log.debug("ilvl: " + ilvl.intValue());
 
 				if (numId==null || numId.signum()==0 || ilvl.signum()<0) {

--- a/docx4j-core/src/main/java/org/docx4j/convert/out/html/XsltHTMLFunctions.java
+++ b/docx4j-core/src/main/java/org/docx4j/convert/out/html/XsltHTMLFunctions.java
@@ -614,9 +614,9 @@ public class XsltHTMLFunctions {
 						&& pPr.getNumPr().getNumId().getVal().longValue()!=0 //zero means no numbering
 						) {
 					Ind numInd = org.docx4j.model.listnumbering.Emulator.getInd(
-	        			context.getWmlPackage(), pStyleVal, 
-	        			pPr.getNumPr().getNumId().getVal().toString(), 
-	        			pPr.getNumPr().getIlvl().getVal().toString() ); 
+							context.getWmlPackage(), pStyleVal,
+							pPr.getNumPr().getNumId().getVal().toString(),
+							org.docx4j.model.listnumbering.Emulator.getIlvlOrDefault(pPr.getNumPr()).toString() );
 					if (numInd!=null) {
 		        		Indent indent = new Indent(pPr.getInd(), numInd);
 		        		pPr.setInd((Ind)indent.getObject());						

--- a/docx4j-core/src/main/java/org/docx4j/model/listnumbering/AbstractListNumberingDefinition.java
+++ b/docx4j-core/src/main/java/org/docx4j/model/listnumbering/AbstractListNumberingDefinition.java
@@ -83,8 +83,11 @@
  */
 package org.docx4j.model.listnumbering;
 
+import java.math.BigInteger;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.docx4j.wml.Lvl;
 import org.docx4j.wml.Numbering;
@@ -180,16 +183,36 @@ public class AbstractListNumberingDefinition {
         {
             //XmlNodeList levelNodes = absNumNode.SelectNodes("./w:lvl", nsm);
 
-        	List<Lvl> levelNodes = abstractNumNode.getLvl(); 
+			List<Lvl> levelNodes = abstractNumNode.getLvl();
             if (this.listLevels == null)
             {
                 this.listLevels = new HashMap<String, ListLevel>(levelNodes.size());
             }
 
+			Set<BigInteger> usedLevels = new HashSet<BigInteger>();
+			for (String existingLevel : this.listLevels.keySet()) {
+				usedLevels.add(new BigInteger(existingLevel));
+			}
+			for (Lvl levelNode : levelNodes) {
+				if (levelNode.getIlvl() != null) {
+					usedLevels.add(levelNode.getIlvl());
+				}
+			}
+
             // loop through the levels it defines and instantiate those
             //foreach (XmlNode levelNode in levelNodes)
             for ( Lvl levelNode : levelNodes )  {
-            	readLevel(levelNode);
+				if (levelNode.getIlvl() == null) {
+					BigInteger fallbackLevel = BigInteger.ZERO;
+					while (usedLevels.contains(fallbackLevel)) {
+						fallbackLevel = fallbackLevel.add(BigInteger.ONE);
+					}
+					log.warn("Missing @w:ilvl on w:lvl in abstractNum {}; assigning {}",
+							abstractNumNode.getAbstractNumId(), fallbackLevel);
+					levelNode.setIlvl(fallbackLevel);
+					usedLevels.add(fallbackLevel);
+				}
+				readLevel(levelNode);
             }
         }
         

--- a/docx4j-core/src/main/java/org/docx4j/model/listnumbering/Emulator.java
+++ b/docx4j-core/src/main/java/org/docx4j/model/listnumbering/Emulator.java
@@ -120,6 +120,25 @@ public class Emulator {
     public Emulator()
     {
     }
+
+	/**
+	 * Returns the explicitly specified paragraph numbering level, or null when
+	 * it is absent or malformed.
+	 */
+	public static BigInteger getExplicitIlvl(NumPr numPr) {
+		if (numPr == null || numPr.getIlvl() == null) {
+			return null;
+		}
+		return numPr.getIlvl().getVal();
+	}
+
+	/**
+	 * Returns the paragraph numbering level, defaulting an omitted level to 0.
+	 */
+	public static BigInteger getIlvlOrDefault(NumPr numPr) {
+		BigInteger ilvl = getExplicitIlvl(numPr);
+		return ilvl == null ? BigInteger.ZERO : ilvl;
+	}
     
 
     /**
@@ -145,9 +164,9 @@ public class Emulator {
 				BigInteger numId = pPr.getNumPr().getNumId().getVal();
 				if (numId!=null) numIdStr = numId.toString();
 			}
-			if (pPr.getNumPr().getIlvl()!=null) {
-				BigInteger levelId = pPr.getNumPr().getIlvl().getVal();
-				if (levelId!=null) levelIdStr = levelId.toString();
+			BigInteger levelId = getExplicitIlvl(pPr.getNumPr());
+			if (levelId != null) {
+				levelIdStr = levelId.toString();
 			}
 		}
 			
@@ -244,10 +263,10 @@ public class Emulator {
     		if (levelId == null 
     				|| levelId.equals("") ) {
     			
-    			if (numPr.getIlvl() != null ) {
-    				
-    				levelId = numPr.getIlvl().getVal().toString();
-    	    		log.info("levelId=" + levelId + " (from style)" );
+			BigInteger explicitIlvl = getExplicitIlvl(numPr);
+			if (explicitIlvl != null ) {
+				levelId = explicitIlvl.toString();
+				log.info("levelId=" + levelId + " (from style)" );
     			} else {
     				// default
     				levelId = "0";
@@ -431,10 +450,10 @@ public class Emulator {
     		if (levelId == null 
     				|| levelId.equals("") ) {
     			
-    			if (numPr.getIlvl() != null ) {
-    				
-    				levelId = numPr.getIlvl().getVal().toString();
-    	    		log.info("levelId=" + levelId + " (from style)" );
+			BigInteger explicitIlvl = getExplicitIlvl(numPr);
+			if (explicitIlvl != null ) {
+				levelId = explicitIlvl.toString();
+				log.info("levelId=" + levelId + " (from style)" );
     			} else {
     				// default
     				levelId = "0";

--- a/docx4j-core/src/main/java/org/docx4j/model/listnumbering/ListLevel.java
+++ b/docx4j-core/src/main/java/org/docx4j/model/listnumbering/ListLevel.java
@@ -139,8 +139,12 @@ public class ListLevel {
     public ListLevel(Lvl levelNode)
     {
     	this.jaxbAbstractLvl = levelNode;
-    	
-        this.id = levelNode.getIlvl().toString(); 
+
+        if (levelNode.getIlvl() == null) {
+            log.warn("Missing @w:ilvl on w:lvl; assigning 0");
+            levelNode.setIlvl(BigInteger.ZERO);
+        }
+        this.id = levelNode.getIlvl().toString();
         
         counter = new Counter();
 

--- a/docx4j-core/src/main/java/org/docx4j/openpackaging/parts/WordprocessingML/NumberingDefinitionsPart.java
+++ b/docx4j-core/src/main/java/org/docx4j/openpackaging/parts/WordprocessingML/NumberingDefinitionsPart.java
@@ -352,9 +352,8 @@ public final class NumberingDefinitionsPart extends JaxbXmlPartXPathAware<Number
 	}
 	
 	public Ind getInd(NumPr numPr) { //, StyleDefinitionsPart sdp, String styleId) {
-		
-		String ilvlString = "0";
-		if (numPr.getIlvl()!=null) ilvlString = numPr.getIlvl().getVal().toString();
+
+		String ilvlString = Emulator.getIlvlOrDefault(numPr).toString();
 		
 		if (numPr.getNumId()==null) {
             if(log.isWarnEnabled()) {

--- a/docx4j-export-fo/src/main/java/org/docx4j/convert/out/fo/FOExporterVisitorGenerator.java
+++ b/docx4j-export-fo/src/main/java/org/docx4j/convert/out/fo/FOExporterVisitorGenerator.java
@@ -46,7 +46,6 @@ import org.docx4j.wml.CTTabStop;
 import org.docx4j.wml.JcEnumeration;
 import org.docx4j.wml.P;
 import org.docx4j.wml.PPr;
-import org.docx4j.wml.PPrBase.NumPr.Ilvl;
 import org.docx4j.wml.R;
 import org.docx4j.wml.RPr;
 import org.docx4j.wml.STBrType;
@@ -340,15 +339,14 @@ public class FOExporterVisitorGenerator extends AbstractVisitorExporterGenerator
 				
 	        	ResultTriple triple;
 	        	if (pPrDirect!=null && pPrDirect.getNumPr()!=null) {
-	        		triple = org.docx4j.model.listnumbering.Emulator.getNumber(
-	        			conversionContext.getWmlPackage(), pStyleVal, 
-	        			pPrDirect.getNumPr().getNumId().getVal().toString(), 
-	        			pPrDirect.getNumPr().getIlvl().getVal().toString() ); 
+				triple = org.docx4j.model.listnumbering.Emulator.getNumber(
+						conversionContext.getWmlPackage(), pStyleVal,
+						pPrDirect.getNumPr().getNumId().getVal().toString(),
+						org.docx4j.model.listnumbering.Emulator.getIlvlOrDefault(pPrDirect.getNumPr()).toString() );
 	        	} else {
 	        		// Get the effective values; since we already know this,
 	        		// save the effort of doing this again in Emulator
-	        		Ilvl ilvl = pPr.getNumPr().getIlvl();
-	        		String ilvlString = ilvl == null ? "0" : ilvl.getVal().toString();
+				String ilvlString = org.docx4j.model.listnumbering.Emulator.getIlvlOrDefault(pPr.getNumPr()).toString();
 	        		triple = null; 
 	        		if (pPr.getNumPr().getNumId()!=null) {
 		        		triple = org.docx4j.model.listnumbering.Emulator.getNumber(

--- a/docx4j-export-fo/src/main/java/org/docx4j/convert/out/fo/XsltFOFunctions.java
+++ b/docx4j-export-fo/src/main/java/org/docx4j/convert/out/fo/XsltFOFunctions.java
@@ -1,19 +1,19 @@
 /*
-   Licensed to Plutext Pty Ltd under one or more contributor license agreements.  
-   
+   Licensed to Plutext Pty Ltd under one or more contributor license agreements.
+
  *  This file is part of docx4j.
 
-    docx4j is licensed under the Apache License, Version 2.0 (the "License"); 
-    you may not use this file except in compliance with the License. 
+    docx4j is licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
 
-    You may obtain a copy of the License at 
+    You may obtain a copy of the License at
 
-        http://www.apache.org/licenses/LICENSE-2.0 
+        http://www.apache.org/licenses/LICENSE-2.0
 
-    Unless required by applicable law or agreed to in writing, software 
-    distributed under the License is distributed on an "AS IS" BASIS, 
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
-    See the License for the specific language governing permissions and 
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
     limitations under the License.
 
  */
@@ -52,7 +52,6 @@ import org.docx4j.wml.CTTwipsMeasure;
 import org.docx4j.wml.HpsMeasure;
 import org.docx4j.wml.JcEnumeration;
 import org.docx4j.wml.PPr;
-import org.docx4j.wml.PPrBase.NumPr.Ilvl;
 import org.docx4j.wml.ParaRPr;
 import org.docx4j.wml.RPr;
 import org.docx4j.wml.STTabJc;
@@ -73,37 +72,37 @@ import org.w3c.dom.Text;
 import org.w3c.dom.traversal.NodeIterator;
 
 
-/** 
- * This class contains static functions that are specific to the FO xsl-transformation and 
- * are called from docx2fo.xslt. 
- *  
+/**
+ * This class contains static functions that are specific to the FO xsl-transformation and
+ * are called from docx2fo.xslt.
+ *
  */
 public class XsltFOFunctions {
-	
+
 	private static Logger log = LoggerFactory.getLogger(XsltFOFunctions.class);
-	
+
 
 	public static DocumentFragment getLayoutMasterSetFragment(AbstractWmlConversionContext context) {
 		return LayoutMasterSetBuilder.getLayoutMasterSetFragment(context);
 	}
-	
-    public static DocumentFragment createBlockForSdt(FOConversionContext context, 
+
+    public static DocumentFragment createBlockForSdt(FOConversionContext context,
     		NodeIterator pPrNodeIt,
     		String pStyleVal, NodeIterator childResults, String tag) {
-    	
+
     	DocumentFragment docfrag = createBlock(context,
         		 pPrNodeIt,
         		 pStyleVal,  childResults,
         		 true);
-    	
+
     	// Set margins, but only for a shading container,
     	// not a borders container
     	if (tag.equals(Containerization.TAG_SHADING) && docfrag!=null) {
     		// docfrag.getNodeName() is  #document-fragment
     	    Node foBlock = docfrag.getFirstChild();
     	    if (foBlock!=null) {
-				((Element)foBlock).setAttribute("margin-top", "0in");    	    	
-				((Element)foBlock).setAttribute("margin-bottom", "0in");    	    	
+				((Element)foBlock).setAttribute("margin-top", "0in");
+				((Element)foBlock).setAttribute("margin-bottom", "0in");
 
 //				((Element)foBlock).setAttribute("padding-top", "0in");
 //				((Element)foBlock).setAttribute("padding-bottom", "0in");
@@ -115,39 +114,39 @@ public class XsltFOFunctions {
     	return docfrag;
     }
 
-    public static DocumentFragment createInlineForSdt( 
+    public static DocumentFragment createInlineForSdt(
     		FOConversionContext context,
     		NodeIterator rPrNodeIt,
     		NodeIterator childResults, String tag) {
-    	
-    	DocumentFragment docfrag = createBlockForRPr( 
+
+    	DocumentFragment docfrag = createBlockForRPr(
         		context,
         		null,
         		rPrNodeIt,
         		childResults);
-    	    
+
     	return docfrag;
-    }	
+    }
     /**
      * This is invoked on every paragraph, whether it has a pPr or not.
-     * 
+     *
      * @param wmlPackage
      * @param pPrNodeIt
      * @param pStyleVal
      * @param childResults - the already transformed contents of the paragraph.
      * @return
      */
-    public static DocumentFragment createBlockForPPr( 
+    public static DocumentFragment createBlockForPPr(
     		FOConversionContext context,
     		NodeIterator pPrNodeIt,
     		String pStyleVal, NodeIterator childResults) {
-    	
-    	DocumentFragment df = createBlock( 
+
+    	DocumentFragment df = createBlock(
         		context,
         		pPrNodeIt,
         		pStyleVal, childResults,
-        		false);  
-    	
+        		false);
+
     	// Note: prior to 17.0.1, an inline with direction="rtl" (as then created by
     	// the TextDirection class for a w:rtl run) was wrapped here in
     	//    <fo:bidi-override direction="rtl" unicode-bidi="embed">
@@ -229,8 +228,8 @@ public class XsltFOFunctions {
     	}
     	return null;
     }
-    
-    
+
+
     /**
      * Recurse sourceNode looking to see whether it contains element with local name elementName
      * @param sourceNode
@@ -243,7 +242,7 @@ public class XsltFOFunctions {
 
 	    	case Node.DOCUMENT_NODE: // type 9
         	case Node.DOCUMENT_FRAGMENT_NODE: // type 11
-        
+
                 // recurse on each child
                 NodeList nodes = sourceNode.getChildNodes();
                 if (nodes != null) {
@@ -254,9 +253,9 @@ public class XsltFOFunctions {
                     }
                 }
                 return false;
-                
+
             case Node.ELEMENT_NODE:
-                
+
                 // Do it...
             	Element el = (Element)sourceNode;
             	if (el.getLocalName().equals(elementName)) {
@@ -277,16 +276,16 @@ public class XsltFOFunctions {
                 return false;
 
             case Node.TEXT_NODE:
-            	
+
                 return false;
-                
+
             default:
-            	
+
                 return false;
         }
     }
-    
-    private static DocumentFragment createBlock( 
+
+    private static DocumentFragment createBlock(
     		FOConversionContext context,
     		NodeIterator pPrNodeIt,
     		String pStyleVal, NodeIterator childResults,
@@ -299,22 +298,22 @@ public class XsltFOFunctions {
 			log.error(e.getMessage(), e);
 	    	return null;
 		}
-    	
+
     	// Note that this is invoked for every paragraph with a pPr node.
-    	
-    	// incoming objects are org.apache.xml.dtm.ref.DTMNodeIterator 
+
+    	// incoming objects are org.apache.xml.dtm.ref.DTMNodeIterator
     	// which implements org.w3c.dom.traversal.NodeIterator
-    	
-		Style defaultParagraphStyle = 
+
+		Style defaultParagraphStyle =
 				(context.getWmlPackage().getMainDocumentPart().getStyleDefinitionsPart(false) != null ?
 				context.getWmlPackage().getMainDocumentPart().getStyleDefinitionsPart(false).getDefaultParagraphStyle() :
 				null);
-		
+
     	String defaultParagraphStyleId;
     	if (defaultParagraphStyle==null) // possible, for non MS source docx
     		defaultParagraphStyleId = "Normal";
     	else defaultParagraphStyleId = defaultParagraphStyle.getStyleId();
-    	
+
 		if ( pStyleVal ==null || pStyleVal.equals("") ) {
 //			pStyleVal = "Normal";
 			pStyleVal = defaultParagraphStyleId;
@@ -323,24 +322,24 @@ public class XsltFOFunctions {
 			log.debug("style '" + pStyleVal );
 		}
 
-    	//    	log.info("pPrNode:" + pPrNodeIt.getClass().getName() ); // org.apache.xml.dtm.ref.DTMNodeIterator    	
-//    	log.info("childResults:" + childResults.getClass().getName() ); 
-    	
-    	
+    	//    	log.info("pPrNode:" + pPrNodeIt.getClass().getName() ); // org.apache.xml.dtm.ref.DTMNodeIterator
+//    	log.info("childResults:" + childResults.getClass().getName() );
+
+
 		/* First, determine effective paragraph and run properties (pPr, rPr) */
     	PPr pPrDirect = null;
-    	
+
     	// Get the pPr node as a JAXB object,
     	// so we can read it using our standard
-    	// methods.  Its a bit sad that we 
+    	// methods.  Its a bit sad that we
     	// can't just adorn our DOM tree with the
     	// original JAXB objects?
     	PPr pPr = null;
     	RPr rPr = null;
     	RPr rPrParagraphMark = null;  // required for list item label
         try {
-        	
-        	if (pPrNodeIt==null) {  // Never happens?        		
+
+        	if (pPrNodeIt==null) {  // Never happens?
     			if (log.isDebugEnabled()) {
     				log.debug("Here after all!!");
     			}
@@ -361,30 +360,30 @@ public class XsltFOFunctions {
         			if (log.isDebugEnabled()) {
         				log.debug( "P actual pPr: "+ XmlUtils.w3CDomNodeToString(n) );
         			}
-        			Unmarshaller u = Context.jc.createUnmarshaller();			
+        			Unmarshaller u = Context.jc.createUnmarshaller();
         			u.setEventHandler(new org.docx4j.jaxb.JaxbValidationEventHandler());
         			Object jaxb = u.unmarshal(n);
     				pPrDirect =  (PPr)jaxb;
-    				pPr = propertyResolver.getEffectivePPr(pPrDirect);  
+    				pPr = propertyResolver.getEffectivePPr(pPrDirect);
     				if ((pPr==null) && (log.isDebugEnabled())) {
     					log.debug("pPr null; obtained from: " + XmlUtils.w3CDomNodeToString(n) );
     				}
-    				
+
     				// On the block representing the w:p, we want to put both
     			    // pPr and rPr attributes.
-    				
+
     				if (log.isDebugEnabled()) {
     					log.debug("getting rPr for paragraph style");
     				}
 
-					// rPr in pPr direct formatting only applies to paragraph mark, 
+					// rPr in pPr direct formatting only applies to paragraph mark,
 					// and by virtue of that, to list item label,
-					// so pass null here.				
+					// so pass null here.
 					// 2018 05, actually, sz also affects line spacing (eg 12 pt on block
             		// with 11 pt inside would have more space), so its important
             		RPr fontSzOnlyRPr = new RPr();
             		if (pPrDirect.getRPr()!=null && pPrDirect.getRPr().getSz()!=null) {
-            			HpsMeasure hm = new HpsMeasure(); 
+            			HpsMeasure hm = new HpsMeasure();
             			hm.setVal( pPrDirect.getRPr().getSz().getVal() ); // does this suffice as a copy?
                 		fontSzOnlyRPr.setSz(hm);
             		}
@@ -392,122 +391,122 @@ public class XsltFOFunctions {
             			// Assume no need to clone
             			fontSzOnlyRPr.setLang(pPrDirect.getRPr().getLang());
             		}
-            		
+
             		rPr = propertyResolver.getEffectiveRPr(fontSzOnlyRPr, pPrDirect);
-            		
+
     				// Now, work out the value for list item label
             		rPrParagraphMark = XmlUtils.deepCopy(rPr);
-    				
-//        			System.out.println("p rpr-->" + XmlUtils.marshaltoString(pPrDirect.getRPr()));
-            		
-            		StyleUtil.apply(pPrDirect.getRPr(), rPrParagraphMark); 
-    				
-        		}
-        	}        	
 
-			if (log.isDebugEnabled() && pPr!=null) {				
-				log.debug("P effective pPr: "+ XmlUtils.marshaltoString(pPr, true, true));					
+//        			System.out.println("p rpr-->" + XmlUtils.marshaltoString(pPrDirect.getRPr()));
+
+            		StyleUtil.apply(pPrDirect.getRPr(), rPrParagraphMark);
+
+        		}
+        	}
+
+			if (log.isDebugEnabled() && pPr!=null) {
+				log.debug("P effective pPr: "+ XmlUtils.marshaltoString(pPr, true, true));
 			}
 		} catch (Exception e) {
 			//log.error(e.getLocalizedMessage(), e);
 			log.error(e.getMessage(), e);
 	    	return null;
-		} 
-			
+		}
+
 		/* Now that we have pPr, we can format the block. */
-		return createBlock(context.getWmlPackage(), context.getRunFontSelector(), pStyleVal, childResults, sdt, pPrDirect, pPr, rPr, rPrParagraphMark); 
-    	    	
+		return createBlock(context.getWmlPackage(), context.getRunFontSelector(), pStyleVal, childResults, sdt, pPrDirect, pPr, rPr, rPrParagraphMark);
+
     }
 
-	protected static DocumentFragment createBlock(WordprocessingMLPackage wmlPackage, RunFontSelector runFontSelector, 
+	protected static DocumentFragment createBlock(WordprocessingMLPackage wmlPackage, RunFontSelector runFontSelector,
 			String pStyleVal, NodeIterator childResults,
 			boolean sdt, PPr pPrDirect, PPr pPr, RPr rPr, RPr rPrParagraphMark) {
 
         try {
-            // Create a DOM builder and parse the fragment			
+            // Create a DOM builder and parse the fragment
 			Document document = XmlUtils.getNewDocumentBuilder().newDocument();
 			//log.info("Document: " + document.getClass().getName() );
-			
+
 			Element foBlockElement = document.createElementNS("http://www.w3.org/1999/XSL/Format", "fo:block");
 			Element foListBlock = null;
 			boolean indentHandledByNumbering = false;
 			// Is it a list item?
-			if (sdt) { 
+			if (sdt) {
 				// Don't convert an SDT into an extra fo:list-block!
 				document.appendChild(foBlockElement);
-			} else if (pPr!=null 
-					&& pPr.getNumPr()!=null 
+			} else if (pPr!=null
+					&& pPr.getNumPr()!=null
 					&& pPr.getNumPr().getNumId()!=null
 					&& pPr.getNumPr().getNumId().getVal().longValue()!=0 //zero means no numbering
 					) {
-				
+
 				foListBlock = document.createElementNS("http://www.w3.org/1999/XSL/Format", "fo:list-block");
 				document.appendChild(foListBlock);
-				
+
 				// Its a list item.  At present we make a new list-block for
 				// each list-item. This is not great; DocumentModel will ultimately
 				// allow us to use fo:list-block properly.
 
 				indentHandledByNumbering = createListBlock(wmlPackage, runFontSelector, pStyleVal, pPrDirect, pPr, rPr,
 						rPrParagraphMark, document, foBlockElement, foListBlock);
-				
+
 				if (log.isDebugEnabled()) {
 					log.debug("bare list result: " + XmlUtils.w3CDomNodeToString(foListBlock) );
 				}
-				
-				
+
+
 			} else /* its not a list item */ {
 				document.appendChild(foBlockElement);
 			}
-			
-			/* Now apply pPr (whether its a list or not) */				
+
+			/* Now apply pPr (whether its a list or not) */
 			if (pPr!=null) {
 				// Ignore paragraph borders once inside the container
 				boolean ignoreBorders = !sdt;
-				createFoAttributes(wmlPackage, pPr, ((Element)foBlockElement), indentHandledByNumbering, ignoreBorders );				
+				createFoAttributes(wmlPackage, pPr, ((Element)foBlockElement), indentHandledByNumbering, ignoreBorders );
 			}
-			
-			/* Now apply rPr */				
+
+			/* Now apply rPr */
 			if (rPr!=null) {
-				
+
 				if (foListBlock==null) {
 					createFoAttributes(wmlPackage, rPr, ((Element)foBlockElement) );
 				} else {
-					createFoAttributes(wmlPackage, rPr, ((Element)foListBlock) );					
+					createFoAttributes(wmlPackage, rPr, ((Element)foListBlock) );
 				}
 	        }
 
 			if (log.isDebugEnabled()) {
 				log.debug("after createFoAttributes: " + XmlUtils.w3CDomNodeToString(foBlockElement) );
 			}
-			
+
 			// Our fo:block wraps whatever result tree fragment
 			// our style sheet produced when it applied-templates
 			// to the child nodes
 			Node n = childResults.nextNode();
-			
+
 			// Handle empty case - want the block to be preserved!
 			if (n.getChildNodes().getLength()==0) {
-				
+
 				((Element)foBlockElement).setAttribute( "white-space-treatment", "preserve");
 				foBlockElement.setTextContent(" ");
-				
+
 			} else {
-			
+
 				/* don't do:
-				 * 
+				 *
 	            ((Element)foBlockElement).setAttribute( "white-space-treatment", "preserve");
 	            ((Element)foBlockElement).setAttribute( "white-space-collapse", "false");
 
-	            Suggested at https://www.docx4java.org/forums/docx-java-f6/export-fo-preserve-whitespaces-t2762.html 
+	            Suggested at https://www.docx4java.org/forums/docx-java-f6/export-fo-preserve-whitespaces-t2762.html
 	            because it causes unwanted formatting issues.  See https://stackoverflow.com/questions/57475550/unwanted-indent-after-line-wrap/57488818
 	            and https://github.com/plutext/docx4j/issues/369
-	            
+
 	            In any subsequent review of this, also consider https://www.docx4java.org/forums/pdf-output-f27/converting-docx-to-pdf-not-preserving-whitespace-t2752.html
-	            
+
 				 */
-	            
-				
+
+
 	//				log.info("Node we are importing: " + n.getClass().getName() );
 	//				foBlockElement.appendChild(
 	//						document.importNode(n, true) );
@@ -515,24 +514,24 @@ public class XsltFOFunctions {
 				 * Node we'd like to import is of type org.apache.xml.dtm.ref.DTMNodeProxy
 				 * which causes
 				 * org.w3c.dom.DOMException: NOT_SUPPORTED_ERR: The implementation does not support the requested type of object or operation.
-				 * 
+				 *
 				 * See http://osdir.com/ml/text.xml.xerces-j.devel/2004-04/msg00066.html
-				 * 
-				 * So instead of importNode, use 
+				 *
+				 * So instead of importNode, use
 				 */
 	            XmlUtils.treeCopy( n,  foBlockElement );
-				
+
 			}
-			
+
 			// FOP doesn't support "ignore-if-surrounding-linefeed", and "pre" is no good, since wrapping does not happen
 			// (so paragraph continues right over edge of page)
 			//((Element)foBlockElement).setAttribute( "white-space", "ignore");
-			
+
 			DocumentFragment docfrag = document.createDocumentFragment();
 			docfrag.appendChild(document.getDocumentElement());
 
 			return docfrag;
-						
+
 		} catch (Exception e) {
 			//log.error(e.getLocalizedMessage(), e);
 			log.error(e.getMessage(), e);
@@ -543,9 +542,9 @@ public class XsltFOFunctions {
 	protected static boolean createListBlock(WordprocessingMLPackage wmlPackage, RunFontSelector runFontSelector,
 			String pStyleVal, PPr pPrDirect, PPr pPr, RPr rPr, RPr rPrParagraphMark, Document document,
 			Element foBlockElement, Element foListBlock) {
-		
+
 		/* Create something like:
-		 * 			
+		 *
 			<fo:list-block provisional-distance-between-starts="0.5in" start-indent="0.5in">
 			  <fo:list-item>
 			    <fo:list-item-label>
@@ -558,81 +557,80 @@ public class XsltFOFunctions {
 			    </fo:list-item-body>
 			  </fo:list-item>
 			</fo:list-block>
-		 */				
-						
+		 */
+
 //				foListBlock.setAttribute("provisional-distance-between-starts", "0.5in");
-		
+
 		boolean indentHandledByNumbering = false;
-		
+
 		// Need to apply shading at fo:list-block level
 		if (pPr.getShd()!=null) {
 			PShading pShading = new PShading(pPr.getShd());
 			pShading.setXslFO(foListBlock);
 		}
-		
-		Element foListItem = document.createElementNS("http://www.w3.org/1999/XSL/Format", "fo:list-item");
-		foListBlock.appendChild(foListItem);				
 
-		
+		Element foListItem = document.createElementNS("http://www.w3.org/1999/XSL/Format", "fo:list-item");
+		foListBlock.appendChild(foListItem);
+
+
 		Element foListItemLabel = document.createElementNS("http://www.w3.org/1999/XSL/Format", "fo:list-item-label");
 		foListItem.appendChild(foListItemLabel);
-		
+
 		Element foListItemLabelBody = document.createElementNS("http://www.w3.org/1999/XSL/Format", "fo:block");
 		foListItemLabel.appendChild(foListItemLabelBody);
 		// the following applies to the label the same ppr props as are applied to the body
 		// but it needs testing
-		// createFoAttributes(wmlPackage, pPr, foListItemLabelBody, true, true );				
-		
-		
+		// createFoAttributes(wmlPackage, pPr, foListItemLabelBody, true, true );
+
+
 		Element foListItemBody = document.createElementNS("http://www.w3.org/1999/XSL/Format", "fo:list-item-body");
-		foListItem.appendChild(foListItemBody);	
+		foListItem.appendChild(foListItemBody);
 		foListItemBody.setAttribute(Indent.FO_NAME, "body-start()");
-		
+
 		ResultTriple triple;
 		if (pPrDirect!=null && pPrDirect.getNumPr()!=null) {
 			triple = org.docx4j.model.listnumbering.Emulator.getNumber(
-					wmlPackage, pStyleVal, 
-				pPrDirect.getNumPr().getNumId().getVal().toString(), 
-				pPrDirect.getNumPr().getIlvl().getVal().toString() ); 
+					wmlPackage, pStyleVal,
+				pPrDirect.getNumPr().getNumId().getVal().toString(),
+				org.docx4j.model.listnumbering.Emulator.getIlvlOrDefault(pPrDirect.getNumPr()).toString() );
 		} else {
 			// Get the effective values; since we already know this,
 			// save the effort of doing this again in Emulator
-			Ilvl ilvl = pPr.getNumPr().getIlvl();
-			String ilvlString = ilvl == null ? "0" : ilvl.getVal().toString();
-			triple = null; 
+			String ilvlString = org.docx4j.model.listnumbering.Emulator.getIlvlOrDefault(pPr.getNumPr()).toString();
+			triple = null;
 			if (pPr.getNumPr().getNumId()!=null) {
 				triple = org.docx4j.model.listnumbering.Emulator.getNumber(
-						wmlPackage, pStyleVal, 
-		    			pPr.getNumPr().getNumId().getVal().toString(), 
-		    			ilvlString ); 		        	
+						wmlPackage, pStyleVal,
+		    			pPr.getNumPr().getNumId().getVal().toString(),
+		    			ilvlString );
 			}
 		}
-		
+
 		if (triple==null) {
 			log.warn("computed number ResultTriple was null");
 			if (log.isDebugEnabled() ) {
 				foListItemLabelBody.setAttribute("color", "red");
 				foListItemLabelBody.setTextContent("null#");
-			} 
+			}
 		} else {
 
 			/* Format the list item label
-			 * 
-			 * Since it turns out (in FOP at least) that the label and the body 
-			 * don't have the same vertical alignment 
+			 *
+			 * Since it turns out (in FOP at least) that the label and the body
+			 * don't have the same vertical alignment
 			 * unless font size is applied at the same level
-			 * (ie to both -label and -body, or to the block inside each), 
+			 * (ie to both -label and -body, or to the block inside each),
 			 * we have to format the list-item-body as well.
 			 * This issue only manifests itself if the font size on
 			 * the outer list-block is larger than the font sizes
 			 * set inside it.
 			 */
-			
+
 			// OK just to override specific values
 			// Values come from numbering rPr, unless overridden in p-level rpr
 			DocumentFragment rfsFrag = null;
 			if(triple.getRPr()==null) {
-				
+
 				if (pPr.getRPr()==null) {
 					// do nothing, since we're already inheriting the formatting in the style
 					// (as opposed to the paragraph mark formatting)
@@ -640,71 +638,71 @@ public class XsltFOFunctions {
 					rfsFrag = (DocumentFragment)runFontSelector.fontSelector(pPr, rPr, triple.getNumString());
 					applyRunFontSelection(rfsFrag, foListItemLabelBody);
 				} else {
-					
-					createFoAttributes(wmlPackage, rPrParagraphMark, foListItemLabel );	        				
-					createFoAttributes(wmlPackage, rPrParagraphMark, foListItemBody );	
-					
+
+					createFoAttributes(wmlPackage, rPrParagraphMark, foListItemLabel );
+					createFoAttributes(wmlPackage, rPrParagraphMark, foListItemBody );
+
 					rfsFrag = (DocumentFragment)runFontSelector.fontSelector(pPr, rPrParagraphMark, triple.getNumString());
 					applyRunFontSelection(rfsFrag, foListItemLabelBody);
 				}
-				
+
 			} else {
 				RPr actual = XmlUtils.deepCopy(triple.getRPr()); // clone, so the ilvl rpr is not altered
 //	        			System.out.println(XmlUtils.marshaltoString(rPrParagraphMark));
-				
+
 				// pMark overrides numbering, except for font
 				// (which makes sense, since that would change the bullet)
 				// so set the font
 				rfsFrag = (DocumentFragment)runFontSelector.fontSelector(pPr, actual, triple.getNumString());
 				applyRunFontSelection(rfsFrag, foListItemLabelBody);
-				
+
 				// .. before taking rPrParagraphMark into account
-				StyleUtil.apply(rPrParagraphMark, actual); 
+				StyleUtil.apply(rPrParagraphMark, actual);
 //	        			System.out.println(XmlUtils.marshaltoString(actual));
-				
+
 				createFoAttributes(wmlPackage, actual, foListItemLabel );
 				createFoAttributes(wmlPackage, actual, foListItemBody );
-				
+
 			}
-				        		
-			
+
+
 			int numChars=1;
 			if (triple.getBullet()!=null ) {
-//				foListItemLabelBody.setTextContent(triple.getBullet() );  
+//				foListItemLabelBody.setTextContent(triple.getBullet() );
 		    	foListItemLabelBody.setTextContent(rfsFrag.getTextContent());  // give effect to any character mapping performed by RFS
-				
+
 			} else if (triple.getNumString()==null) {
 				log.debug("computed NumString was null!");
 				if (log.isDebugEnabled() ) {
 					foListItemLabelBody.setAttribute("color", "red");
 					foListItemLabelBody.setTextContent("null#");
-				} 
+				}
 				numChars=0;
 			} else {
 				Text number = document.createTextNode( triple.getNumString() );
 				foListItemLabelBody.appendChild(number);
 				numChars = triple.getNumString().length();
 			}
-			
+
 			// Indent (setting provisional-distance-between-starts)
 			// Indent on direct pPr (trumps indent specified in
-			// direct numbering??) which trumps indent in pPr in style, 
-			// which trumps indent specified in a style's numbering.  
+			// direct numbering??) which trumps indent in pPr in style,
+			// which trumps indent specified in a style's numbering.
 			// Well, not exactly, components which aren't set in
 			// the direct formatting will be contributed by the numbering's indent settings
 			Indent indent = new Indent(pPrDirect.getInd(), triple.getIndent());
 			if (indent.isHanging() ) {
-				indent.setXslFOListBlock(foListBlock, -1);	        			
+				indent.setXslFOListBlock(foListBlock, -1);
 			} else {
-				
+
 				int numWidth = 90 * numChars; // crude .. TODO take font size into account
-				
+
 			    int pdbs = getDistanceToNextTabStop(indent.getNumberPosition(), numWidth,
 			    		pPrDirect.getTabs(), wmlPackage.getMainDocumentPart().getDocumentSettingsPart());
-				indent.setXslFOListBlock(foListBlock, pdbs);	        				        			
+				indent.setXslFOListBlock(foListBlock, pdbs);
 			}
-			indentHandledByNumbering = true; 
-			
+			indentHandledByNumbering = true;
+
 //	        		// Set the font
 //	        		if (triple.getNumFont()!=null) {
 //	        			String font = PhysicalFonts.getPhysicalFont(context.getWmlPackage(), triple.getNumFont() );
@@ -712,23 +710,23 @@ public class XsltFOFunctions {
 //	        				foListItemLabelBody.setAttribute("font-family", font );
 //	        			}
 //	        		}
-			
+
 		}
 		foListItemBody.appendChild(foBlockElement);
 		return indentHandledByNumbering;
 	}
-    
-    
+
+
     /**
      * Use RunFontSelector result to set the correct font for the list item label.
      */
     protected static void applyRunFontSelection(DocumentFragment frag, Element foListItemLabelBody) {
-    	
+
     	if (log.isDebugEnabled()) {
     		log.debug(XmlUtils.w3CDomNodeToString(frag));
     	}
     	// eg <fo:inline xmlns:fo="http://www.w3.org/1999/XSL/Format" font-family="Times New Roman">1)</fo:inline>
-    	
+
     	// Now get the attribute value
     	if (frag!=null && frag.getFirstChild()!=null) {
     		Attr attr = ((Element)frag.getFirstChild()).getAttributeNode("font-family");
@@ -736,33 +734,33 @@ public class XsltFOFunctions {
     			foListItemLabelBody.setAttribute("font-family", attr.getValue());
     		}
     	}
-			
+
     }
-    
+
     protected static int getDistanceToNextTabStop( int pos, int numWidth, Tabs pprTabs, DocumentSettingsPart settings) {
     	// Also used by FOExporterVisitorGenerator, so should be moved
-    	    	
-		int pdbs = 0; 
+
+		int pdbs = 0;
 		int defaultTab = 360;
 		if (pprTabs!=null
 				&& pprTabs.getTab()!=null
 				&& pprTabs.getTab().size()>0) {
-			
+
 			for ( CTTabStop tabStop : pprTabs.getTab() ) {
 					if (tabStop.getPos().intValue()> (pos+ numWidth) ) {
 						log.debug("tab stop: using specified");
 						return (tabStop.getPos().intValue() - pos);
 					}
 			}
-			
-		} 
-		
+
+		}
+
 		// The default tabs continue to apply after the specified ones
 		if (settings!=null
 				&& settings.getJaxbElement().getDefaultTabStop()!=null ) {
 			CTTwipsMeasure twips = settings.getJaxbElement().getDefaultTabStop();
 			defaultTab = twips.getVal().intValue();
-			
+
 			if (defaultTab>0) {
 				log.debug("tab stop: using default from docx");
 				int tabNUmber = (int)Math.floor((pos+numWidth)/defaultTab);
@@ -778,22 +776,22 @@ public class XsltFOFunctions {
     }
 
 	private static void createFoAttributes(OpcPackage opcPackage, PPr pPr, Element foBlockElement, boolean inList, boolean ignoreBorders){
-		
+
     	List<Property> properties = PropertyFactory.createProperties(opcPackage, pPr);
-    	
+
     	for( Property p :  properties ) {
 			if (p!=null) {
-				
+
 				if (ignoreBorders &&
 						((p instanceof PBorderTop)
 								|| (p instanceof PBorderBottom))) {
 					continue;
 				}
-								
-				if (inList && !(p instanceof Indent) ) { 
-					// Don't set start-indent in 
+
+				if (inList && !(p instanceof Indent) ) {
+					// Don't set start-indent in
 					// fo:list-item-body/fo:block.
-					// This has to be handled above using something like 
+					// This has to be handled above using something like
 					//  <fo:list-block provisional-distance-between-starts="0.5in" start-indent="2in">
 					p.setXslFO(foBlockElement);
 				} else if (!inList) {
@@ -801,13 +799,13 @@ public class XsltFOFunctions {
 				}
 			}
     	}
-    	
+
     	if (pPr==null) return;
-		
+
     	// Special case, since bidi is translated to align right
     	// Handle interaction between w:pPr/w:bidi and w:pPr/w:jc/@w:val='right'
     	if (pPr.getBidi()!=null && pPr.getBidi().isVal()) {
-    		
+
     		if (pPr.getJc()!=null) {
     			if (pPr.getJc().getVal().equals(JcEnumeration.RIGHT)) {
     				// set it to left!
@@ -818,28 +816,28 @@ public class XsltFOFunctions {
     			}
     		}
     	}
-    	
+
     	// Table of contents dot leader needs text-align-last="justify"
     	// Are we in a TOC?
     	if (pPr.getTabs()!=null
-    			
+
     			// PStyle is not included in our effective pPr!
-//    			&& pPr.getPStyle()!=null 
+//    			&& pPr.getPStyle()!=null
 //    			&& pPr.getPStyle().getVal()!=null
-//    			&& pPr.getPStyle().getVal().startsWith("TOC")  
+//    			&& pPr.getPStyle().getVal().startsWith("TOC")
     			) {
-    		
+
     		CTTabStop tabStop = pPr.getTabs().getTab().get(0);
     		if (tabStop!=null
     				//&& tabStop.getLeader().equals(STTabTlc.DOT)
     				&& tabStop.getVal().equals(STTabJc.RIGHT) ) {
-    			
+
     			foBlockElement.setAttribute("text-align-last",  "justify");
     		}
     	}
-    	
+
 	}
-	
+
 	/*
 	 *  @since 3.0.0
 	 */
@@ -850,35 +848,35 @@ public class XsltFOFunctions {
 			}
 		}
 	}
-	
+
     private static void createFoAttributes(TrPr trPr, Element foBlockElement){
     	if (trPr == null) {
     		return;
     	}
     	applyFoAttributes(PropertyFactory.createProperties(trPr), foBlockElement);
     }
-	
+
     private static void createFoAttributes(TcPr tcPr, Element foBlockElement){
     	// includes TcPrInner.TcBorders, CTShd, TcMar, CTVerticalJc
-    	
+
 		if (tcPr==null) {
 			return;
 		}
     	applyFoAttributes(PropertyFactory.createProperties(tcPr), foBlockElement);
     }
-	
+
 
     /**
      * On a block representing a run, we just put run properties
      * from this rPr node. The paragraph style rPr's have been
      * taken care of on the fo block which represents the paragraph.
-     * 
+     *
      * @param wmlPackage
      * @param rPrNodeIt
      * @param childResults
      * @return
      */
-    public static DocumentFragment createBlockForRPr( 
+    public static DocumentFragment createBlockForRPr(
     		FOConversionContext context,
     		NodeIterator pPrNodeIt,
     		NodeIterator rPrNodeIt,
@@ -886,22 +884,22 @@ public class XsltFOFunctions {
 
         try {
         	PropertyResolver propertyResolver = context.getPropertyResolver();
-    	
+
     	// Note that this is invoked for every paragraph with a pPr node.
-    	
-    	// incoming objects are org.apache.xml.dtm.ref.DTMNodeIterator 
+
+    	// incoming objects are org.apache.xml.dtm.ref.DTMNodeIterator
     	// which implements org.w3c.dom.traversal.NodeIterator
 
-    	
-//    	log.info("rPrNode:" + rPrNodeIt.getClass().getName() ); // org.apache.xml.dtm.ref.DTMNodeIterator    	
-//    	log.info("childResults:" + childResults.getClass().getName() ); 
-    	
-    	
-        	
-			Unmarshaller u = Context.jc.createUnmarshaller();			
+
+//    	log.info("rPrNode:" + rPrNodeIt.getClass().getName() ); // org.apache.xml.dtm.ref.DTMNodeIterator
+//    	log.info("childResults:" + childResults.getClass().getName() );
+
+
+
+			Unmarshaller u = Context.jc.createUnmarshaller();
 			u.setEventHandler(new org.docx4j.jaxb.JaxbValidationEventHandler());
 
-			// If there is w:pPr/w:pStyle,			
+			// If there is w:pPr/w:pStyle,
 			// we need to honour any rPr in the pStyle
 			PPr pPrDirect = null;
         	if (pPrNodeIt!=null) {
@@ -912,11 +910,11 @@ public class XsltFOFunctions {
         				pPrDirect =  (PPr)jaxb;
         			} catch (ClassCastException e) {
         		    	log.error("Couldn't cast to PPr " + jaxb.getClass().getName() + " to PPr!");
-        			}        	        			
+        			}
         		}
         	}
-        	
-			Object jaxbR = u.unmarshal(rPrNodeIt.nextNode());			
+
+			Object jaxbR = u.unmarshal(rPrNodeIt.nextNode());
 			//RPr rPrDirect = null;
 			RPr rPr = null;
 			if (jaxbR instanceof RPr) {
@@ -927,114 +925,114 @@ public class XsltFOFunctions {
 //					Throwable t = new Throwable();
 //					log.debug("passed ParaRPr", t);
 //				}
-				
-				rPr = propertyResolver.getEffectiveRPr(null, pPrDirect); 
+
+				rPr = propertyResolver.getEffectiveRPr(null, pPrDirect);
 //    			System.out.println("p rpr-->" + XmlUtils.marshaltoString(pPrDirect.getRPr()));
-        		
-        		StyleUtil.apply((ParaRPr)jaxbR, rPr); 				
-				
+
+        		StyleUtil.apply((ParaRPr)jaxbR, rPr);
+
 			} else {
 				log.error("TODO handle  .." + jaxbR.getClass().getName());
-			}        	
-        	
-			
+			}
+
+
             // Create a DOM builder and parse the fragment
 			Document document = XmlUtils.getNewDocumentBuilder().newDocument();
-			
+
 			//log.info("Document: " + document.getClass().getName() );
 
-			Node foInlineElement = document.createElementNS("http://www.w3.org/1999/XSL/Format", "fo:inline");			
+			Node foInlineElement = document.createElementNS("http://www.w3.org/1999/XSL/Format", "fo:inline");
 			document.appendChild(foInlineElement);
-			
-				
-//			if (log.isDebugEnabled() && rPr!=null) {					
-//				log.debug(XmlUtils.marshaltoString(rPr, true, true));					
+
+
+//			if (log.isDebugEnabled() && rPr!=null) {
+//				log.debug(XmlUtils.marshaltoString(rPr, true, true));
 //			}
-			
-			//if (rPr!=null) {				
+
+			//if (rPr!=null) {
 				createFoAttributes(context.getWmlPackage(), rPr, ((Element)foInlineElement) );
 			//}
-			
+
 			// Our fo:block wraps whatever result tree fragment
 			// our style sheet produced when it applied-templates
 			// to the child nodes
 			Node n = childResults.nextNode();
-			XmlUtils.treeCopy( n,  foInlineElement );			
-			
+			XmlUtils.treeCopy( n,  foInlineElement );
+
 			DocumentFragment docfrag = document.createDocumentFragment();
 			docfrag.appendChild(document.getDocumentElement());
 
 			return docfrag;
-						
+
 		} catch (Exception e) {
 			log.error(e.getMessage(), e);
-		} 
-    	
+		}
+
     	return null;
-    	
+
     }
 
 	private static void createFoAttributes(OpcPackage opcPackage,
 			RPr rPr, Element foInlineElement){
 
     	List<Property> properties = PropertyFactory.createProperties(opcPackage, rPr);
-    	
+
     	for( Property p :  properties ) {
     		p.setXslFO(foInlineElement);
     	}
-		
+
 	}
-	
+
     public static String getPageNumberFormat(FOConversionContext context) {
-    	String pageFormat = 
+    	String pageFormat =
     			context.getSections().getCurrentSection().getPageNumberInformation().getPageFormat();
     	//may return empty string if no page number format supplied
     	pageFormat = FormattingSwitchHelper.getFoPageNumberFormat(pageFormat);
     	return (pageFormat == null ? "" : pageFormat);
     }
-	
+
     public static String getPageNumberInitial(FOConversionContext context) {
-    	int ret = 
+    	int ret =
     			context.getSections().getCurrentSection().getPageNumberInformation().getPageStart();
     	//may return empty string if no start page number supplied
     	return (ret == -1 ? "" : Integer.toString(ret));
     }
-    
+
     /**
      * FOP inserts a blank page if necessary so that a section with page numbering
      * from 1 would be face up when printed double sided. Word doesn't do that
-     * (unless you have an odd section type), so this function mimics Word's 
-     * behaviour. 
-     * 
+     * (unless you have an odd section type), so this function mimics Word's
+     * behaviour.
+     *
      * @param context
      * @return
      * @since 3.2.2
      */
     public static String getForcePageCount(FOConversionContext context) {
-    	
+
     	// see http://www.w3.org/TR/xsl/#force-page-count
-    	
+
     	ConversionSectionWrapper wrapper = context.getSections().peekNextSection();
-    	
+
     	if (wrapper==null) {
     		// final section
     		return "no-force";
     	} else {
     		SectPr.Type secType = wrapper.getSectPr().getType();
-    		
+
     		CTPageNumber pgNumType = wrapper.getSectPr().getPgNumType();
     		Boolean isExplicitOdd = null; // null means numbering will continue from the highest page number in the previous section
     		if (pgNumType!=null && pgNumType.getStart()!=null) {
     			int start = pgNumType.getStart().intValue();
     			if ( start % 2 == 0) {
-    				isExplicitOdd = Boolean.FALSE;    				
+    				isExplicitOdd = Boolean.FALSE;
     			} else {
-    				isExplicitOdd = Boolean.TRUE;    				    				
+    				isExplicitOdd = Boolean.TRUE;
     			}
     		}
-    		
+
     		if (secType==null || secType.getVal().equals("nextPage") ) {
-        		return "no-force";  
+        		return "no-force";
     		} else if (isExplicitOdd==null  // LIMITATION: We don't get this right after the user has set the page number explicitly in a previous section
     						|| isExplicitOdd) {
     			// The normal case
@@ -1047,7 +1045,7 @@ public class XsltFOFunctions {
 	    			return "end-on-even";
 	    		} else {
 	    			// continuous (!)
-	        		return "no-force";    			    			
+	        		return "no-force";
 	    		}
     		} else {
     			// section starts with p2 or p4
@@ -1060,18 +1058,18 @@ public class XsltFOFunctions {
 	    			return "end-on-odd";
 	    		} else {
 	    			// continuous (!)
-	        		return "no-force";    			    			
+	        		return "no-force";
 	    		}
-    			
+
     		}
     	}
 
     }
-    
+
     private static boolean isOdd(SectPr sectPr) {
-    	
+
     	CTPageNumber pgNumType = sectPr.getPgNumType();
-    	
+
     	return true;
     }
 


### PR DESCRIPTION
Normalize missing abstract numbering level IDs without overwriting existing levels.

Centralize paragraph numbering level resolution and default omitted or malformed values to level 0 across HTML and FO conversion paths.

Add regression tests for direct construction, malformed paragraph levels, and linked numbering styles.

<!-- Thanks for contributing to docx4j! Please see CONTRIBUTING.md. -->

## What does this PR do?

https://github.com/plutext/docx4j/issues/593

This PR improves the handling of missing or malformed numbering level values and prevents `NullPointerException`s during HTML and FO conversion.

It:

- Normalizes missing `w:lvl/@w:ilvl` values when abstract numbering definitions are loaded.
- Assigns the first available level ID without overwriting existing levels, including levels populated through linked numbering styles.
- Centralizes paragraph numbering level resolution in `Emulator`.
- Defaults omitted or malformed `w:numPr/w:ilvl` values to level `0` when the level is consumed.
- Applies the same null-safe behavior across HTML, XSLT, visitor-based, and FO conversion paths.
- Preserves nullable explicit-level handling where style resolution may still be required.
- Adds regression tests covering:
  - Direct `ListLevel` construction with a missing level ID.
  - Missing paragraph numbering levels.
  - Numbering levels with a missing `val`.
  - Allocation when level `0` is already occupied.
  - Linked numbering styles without overwriting existing levels.


## Checklist

- [x] Each commit carries a `Signed-off-by:` line added by me (DCO — see
      CONTRIBUTING.md), certifying I have the right to submit this under the
      Apache License v2.
- [x] Any AI assistance is disclosed via a commit trailer
      (`Assisted-by:` / `Generated-by:` / `Co-Authored-By:`), and I have
      personally reviewed, understood, and can explain all of the code.
- [x] Tests pass locally (`mvn test -pl docx4j-core-tests -am`), and I added
      or extended a test where practical.
- [x] `CHANGELOG.md` is updated if the change is user-visible.
