### PR TITLE
Handle missing numbering level values safely, NPE in ListLevel.java

### DIFF
--- a/docx4j-core-tests/src/test/java/org/docx4j/model/listnumbering/NumberingLevelNullSafetyTest.java
+++ b/docx4j-core-tests/src/test/java/org/docx4j/model/listnumbering/NumberingLevelNullSafetyTest.java
@@ -1,0 +1,85 @@
+package org.docx4j.model.listnumbering;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+
+import java.math.BigInteger;
+
+import org.docx4j.wml.Lvl;
+import org.docx4j.wml.Numbering;
+import org.docx4j.wml.PPrBase.NumPr;
+import org.junit.Test;
+
+public class NumberingLevelNullSafetyTest {
+
+	@Test
+	public void directListLevelConstructionDefaultsMissingIdToZero() {
+		Lvl level = new Lvl();
+
+		ListLevel listLevel = new ListLevel(level);
+
+		assertEquals(BigInteger.ZERO, level.getIlvl());
+		assertEquals("0", listLevel.getID());
+	}
+
+	@Test
+	public void missingAbstractLevelIdUsesFirstAvailableLevel() {
+		Numbering.AbstractNum abstractNum = new Numbering.AbstractNum();
+		abstractNum.setAbstractNumId(BigInteger.ZERO);
+
+		Lvl missingLevelId = new Lvl();
+		Lvl levelZero = new Lvl();
+		levelZero.setIlvl(BigInteger.ZERO);
+		abstractNum.getLvl().add(missingLevelId);
+		abstractNum.getLvl().add(levelZero);
+
+		AbstractListNumberingDefinition definition = new AbstractListNumberingDefinition(abstractNum);
+
+		assertEquals(BigInteger.ONE, missingLevelId.getIlvl());
+		assertSame(missingLevelId, definition.getListLevels().get("1").getJaxbAbstractLvl());
+		assertSame(levelZero, definition.getListLevels().get("0").getJaxbAbstractLvl());
+	}
+
+	@Test
+	public void linkedStyleLevelDoesNotOverwriteExistingLevel() {
+		Numbering.AbstractNum abstractNum = new Numbering.AbstractNum();
+		abstractNum.setAbstractNumId(BigInteger.ZERO);
+		Numbering.AbstractNum.NumStyleLink numStyleLink = new Numbering.AbstractNum.NumStyleLink();
+		numStyleLink.setVal("LinkedListStyle");
+		abstractNum.setNumStyleLink(numStyleLink);
+
+		Lvl levelZero = new Lvl();
+		levelZero.setIlvl(BigInteger.ZERO);
+		abstractNum.getLvl().add(levelZero);
+
+		AbstractListNumberingDefinition definition = new AbstractListNumberingDefinition(abstractNum);
+		Numbering.AbstractNum linkedAbstractNum = new Numbering.AbstractNum();
+		linkedAbstractNum.setAbstractNumId(BigInteger.ONE);
+		Lvl linkedLevelWithoutId = new Lvl();
+		linkedAbstractNum.getLvl().add(linkedLevelWithoutId);
+
+		definition.updateDefinitionFromLinkedStyle(linkedAbstractNum);
+
+		assertEquals(BigInteger.ONE, linkedLevelWithoutId.getIlvl());
+		assertSame(levelZero, definition.getListLevels().get("0").getJaxbAbstractLvl());
+		assertSame(linkedLevelWithoutId, definition.getListLevels().get("1").getJaxbAbstractLvl());
+	}
+
+	@Test
+	public void missingParagraphLevelDefaultsToZero() {
+		NumPr numPr = new NumPr();
+
+		assertNull(Emulator.getExplicitIlvl(numPr));
+		assertEquals(BigInteger.ZERO, Emulator.getIlvlOrDefault(numPr));
+	}
+
+	@Test
+	public void paragraphLevelWithoutValueDefaultsToZero() {
+		NumPr numPr = new NumPr();
+		numPr.setIlvl(new NumPr.Ilvl());
+
+		assertNull(Emulator.getExplicitIlvl(numPr));
+		assertEquals(BigInteger.ZERO, Emulator.getIlvlOrDefault(numPr));
+	}
+}

--- a/docx4j-core/src/main/java/org/docx4j/convert/out/html/HTMLExporterVisitorGenerator.java
+++ b/docx4j-core/src/main/java/org/docx4j/convert/out/html/HTMLExporterVisitorGenerator.java
@@ -19,6 +19,8 @@
  */
 package org.docx4j.convert.out.html;
 
+import java.math.BigInteger;
+
 import org.docx4j.convert.out.common.AbstractVisitorExporterDelegate;
 import org.docx4j.convert.out.common.AbstractVisitorExporterDelegate.AbstractVisitorExporterGeneratorFactory;
 import org.docx4j.convert.out.common.AbstractVisitorExporterGenerator;
@@ -115,7 +117,8 @@ public class HTMLExporterVisitorGenerator extends AbstractVisitorExporterGenerat
 			String levelId=null;
 			if (pPrDirect.getNumPr()!=null) {
 				numId = pPrDirect.getNumPr().getNumId()==null ? null : pPrDirect.getNumPr().getNumId().getVal().toString(); 
-				levelId = pPrDirect.getNumPr().getIlvl()==null ? null : pPrDirect.getNumPr().getIlvl().getVal().toString(); 
+				BigInteger explicitIlvl = org.docx4j.model.listnumbering.Emulator.getExplicitIlvl(pPrDirect.getNumPr());
+				levelId = explicitIlvl == null ? null : explicitIlvl.toString();
 			}
 			
         	ResultTriple triple = org.docx4j.model.listnumbering.Emulator.getNumber(

--- a/docx4j-core/src/main/java/org/docx4j/convert/out/html/ListsToContentControls.java
+++ b/docx4j-core/src/main/java/org/docx4j/convert/out/html/ListsToContentControls.java
@@ -12,6 +12,7 @@ import org.docx4j.finders.SdtFinder;
 import org.docx4j.finders.TcFinder;
 import org.docx4j.model.PropertyResolver;
 import org.docx4j.model.listnumbering.AbstractListNumberingDefinition;
+import org.docx4j.model.listnumbering.Emulator;
 import org.docx4j.model.listnumbering.ListLevel;
 import org.docx4j.model.listnumbering.ListNumberingDefinition;
 import org.docx4j.openpackaging.exceptions.CyclicStylesException;
@@ -349,12 +350,7 @@ public class ListsToContentControls {
 				
 				BigInteger numId = numPr.getNumId().getVal();
 				
-				BigInteger ilvl = null;
-				if (numPr.getIlvl()==null) {
-					ilvl = BigInteger.ZERO;
-				} else {
-					ilvl = numPr.getIlvl().getVal();
-				}
+				BigInteger ilvl = Emulator.getIlvlOrDefault(numPr);
 				log.debug("ilvl: " + ilvl.intValue());
 
 				if (numId==null || numId.signum()==0 || ilvl.signum()<0) {

--- a/docx4j-core/src/main/java/org/docx4j/convert/out/html/XsltHTMLFunctions.java
+++ b/docx4j-core/src/main/java/org/docx4j/convert/out/html/XsltHTMLFunctions.java
@@ -614,9 +614,9 @@ public class XsltHTMLFunctions {
 						&& pPr.getNumPr().getNumId().getVal().longValue()!=0 //zero means no numbering
 						) {
 					Ind numInd = org.docx4j.model.listnumbering.Emulator.getInd(
-	        			context.getWmlPackage(), pStyleVal, 
-	        			pPr.getNumPr().getNumId().getVal().toString(), 
-	        			pPr.getNumPr().getIlvl().getVal().toString() ); 
+							context.getWmlPackage(), pStyleVal,
+							pPr.getNumPr().getNumId().getVal().toString(),
+							org.docx4j.model.listnumbering.Emulator.getIlvlOrDefault(pPr.getNumPr()).toString() );
 					if (numInd!=null) {
 		        		Indent indent = new Indent(pPr.getInd(), numInd);
 		        		pPr.setInd((Ind)indent.getObject());						

--- a/docx4j-core/src/main/java/org/docx4j/model/listnumbering/AbstractListNumberingDefinition.java
+++ b/docx4j-core/src/main/java/org/docx4j/model/listnumbering/AbstractListNumberingDefinition.java
@@ -83,8 +83,11 @@
  */
 package org.docx4j.model.listnumbering;
 
+import java.math.BigInteger;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.docx4j.wml.Lvl;
 import org.docx4j.wml.Numbering;
@@ -180,16 +183,36 @@ public class AbstractListNumberingDefinition {
         {
             //XmlNodeList levelNodes = absNumNode.SelectNodes("./w:lvl", nsm);
 
-        	List<Lvl> levelNodes = abstractNumNode.getLvl(); 
+			List<Lvl> levelNodes = abstractNumNode.getLvl();
             if (this.listLevels == null)
             {
                 this.listLevels = new HashMap<String, ListLevel>(levelNodes.size());
             }
 
+			Set<BigInteger> usedLevels = new HashSet<BigInteger>();
+			for (String existingLevel : this.listLevels.keySet()) {
+				usedLevels.add(new BigInteger(existingLevel));
+			}
+			for (Lvl levelNode : levelNodes) {
+				if (levelNode.getIlvl() != null) {
+					usedLevels.add(levelNode.getIlvl());
+				}
+			}
+
             // loop through the levels it defines and instantiate those
             //foreach (XmlNode levelNode in levelNodes)
             for ( Lvl levelNode : levelNodes )  {
-            	readLevel(levelNode);
+				if (levelNode.getIlvl() == null) {
+					BigInteger fallbackLevel = BigInteger.ZERO;
+					while (usedLevels.contains(fallbackLevel)) {
+						fallbackLevel = fallbackLevel.add(BigInteger.ONE);
+					}
+					log.warn("Missing @w:ilvl on w:lvl in abstractNum {}; assigning {}",
+							abstractNumNode.getAbstractNumId(), fallbackLevel);
+					levelNode.setIlvl(fallbackLevel);
+					usedLevels.add(fallbackLevel);
+				}
+				readLevel(levelNode);
             }
         }
         

--- a/docx4j-core/src/main/java/org/docx4j/model/listnumbering/Emulator.java
+++ b/docx4j-core/src/main/java/org/docx4j/model/listnumbering/Emulator.java
@@ -120,6 +120,25 @@ public class Emulator {
     public Emulator()
     {
     }
+
+	/**
+	 * Returns the explicitly specified paragraph numbering level, or null when
+	 * it is absent or malformed.
+	 */
+	public static BigInteger getExplicitIlvl(NumPr numPr) {
+		if (numPr == null || numPr.getIlvl() == null) {
+			return null;
+		}
+		return numPr.getIlvl().getVal();
+	}
+
+	/**
+	 * Returns the paragraph numbering level, defaulting an omitted level to 0.
+	 */
+	public static BigInteger getIlvlOrDefault(NumPr numPr) {
+		BigInteger ilvl = getExplicitIlvl(numPr);
+		return ilvl == null ? BigInteger.ZERO : ilvl;
+	}
     
 
     /**
@@ -145,9 +164,9 @@ public class Emulator {
 				BigInteger numId = pPr.getNumPr().getNumId().getVal();
 				if (numId!=null) numIdStr = numId.toString();
 			}
-			if (pPr.getNumPr().getIlvl()!=null) {
-				BigInteger levelId = pPr.getNumPr().getIlvl().getVal();
-				if (levelId!=null) levelIdStr = levelId.toString();
+			BigInteger levelId = getExplicitIlvl(pPr.getNumPr());
+			if (levelId != null) {
+				levelIdStr = levelId.toString();
 			}
 		}
 			
@@ -244,10 +263,10 @@ public class Emulator {
     		if (levelId == null 
     				|| levelId.equals("") ) {
     			
-    			if (numPr.getIlvl() != null ) {
-    				
-    				levelId = numPr.getIlvl().getVal().toString();
-    	    		log.info("levelId=" + levelId + " (from style)" );
+			BigInteger explicitIlvl = getExplicitIlvl(numPr);
+			if (explicitIlvl != null ) {
+				levelId = explicitIlvl.toString();
+				log.info("levelId=" + levelId + " (from style)" );
     			} else {
     				// default
     				levelId = "0";
@@ -431,10 +450,10 @@ public class Emulator {
     		if (levelId == null 
     				|| levelId.equals("") ) {
     			
-    			if (numPr.getIlvl() != null ) {
-    				
-    				levelId = numPr.getIlvl().getVal().toString();
-    	    		log.info("levelId=" + levelId + " (from style)" );
+			BigInteger explicitIlvl = getExplicitIlvl(numPr);
+			if (explicitIlvl != null ) {
+				levelId = explicitIlvl.toString();
+				log.info("levelId=" + levelId + " (from style)" );
     			} else {
     				// default
     				levelId = "0";

--- a/docx4j-core/src/main/java/org/docx4j/model/listnumbering/ListLevel.java
+++ b/docx4j-core/src/main/java/org/docx4j/model/listnumbering/ListLevel.java
@@ -139,8 +139,12 @@ public class ListLevel {
     public ListLevel(Lvl levelNode)
     {
     	this.jaxbAbstractLvl = levelNode;
-    	
-        this.id = levelNode.getIlvl().toString(); 
+
+        if (levelNode.getIlvl() == null) {
+            log.warn("Missing @w:ilvl on w:lvl; assigning 0");
+            levelNode.setIlvl(BigInteger.ZERO);
+        }
+        this.id = levelNode.getIlvl().toString();
         
         counter = new Counter();
 

--- a/docx4j-core/src/main/java/org/docx4j/openpackaging/parts/WordprocessingML/NumberingDefinitionsPart.java
+++ b/docx4j-core/src/main/java/org/docx4j/openpackaging/parts/WordprocessingML/NumberingDefinitionsPart.java
@@ -352,9 +352,8 @@ public final class NumberingDefinitionsPart extends JaxbXmlPartXPathAware<Number
 	}
 	
 	public Ind getInd(NumPr numPr) { //, StyleDefinitionsPart sdp, String styleId) {
-		
-		String ilvlString = "0";
-		if (numPr.getIlvl()!=null) ilvlString = numPr.getIlvl().getVal().toString();
+
+		String ilvlString = Emulator.getIlvlOrDefault(numPr).toString();
 		
 		if (numPr.getNumId()==null) {
             if(log.isWarnEnabled()) {

--- a/docx4j-export-fo/src/main/java/org/docx4j/convert/out/fo/FOExporterVisitorGenerator.java
+++ b/docx4j-export-fo/src/main/java/org/docx4j/convert/out/fo/FOExporterVisitorGenerator.java
@@ -46,7 +46,6 @@ import org.docx4j.wml.CTTabStop;
 import org.docx4j.wml.JcEnumeration;
 import org.docx4j.wml.P;
 import org.docx4j.wml.PPr;
-import org.docx4j.wml.PPrBase.NumPr.Ilvl;
 import org.docx4j.wml.R;
 import org.docx4j.wml.RPr;
 import org.docx4j.wml.STBrType;
@@ -340,15 +339,14 @@ public class FOExporterVisitorGenerator extends AbstractVisitorExporterGenerator
 				
 	        	ResultTriple triple;
 	        	if (pPrDirect!=null && pPrDirect.getNumPr()!=null) {
-	        		triple = org.docx4j.model.listnumbering.Emulator.getNumber(
-	        			conversionContext.getWmlPackage(), pStyleVal, 
-	        			pPrDirect.getNumPr().getNumId().getVal().toString(), 
-	        			pPrDirect.getNumPr().getIlvl().getVal().toString() ); 
+				triple = org.docx4j.model.listnumbering.Emulator.getNumber(
+						conversionContext.getWmlPackage(), pStyleVal,
+						pPrDirect.getNumPr().getNumId().getVal().toString(),
+						org.docx4j.model.listnumbering.Emulator.getIlvlOrDefault(pPrDirect.getNumPr()).toString() );
 	        	} else {
 	        		// Get the effective values; since we already know this,
 	        		// save the effort of doing this again in Emulator
-	        		Ilvl ilvl = pPr.getNumPr().getIlvl();
-	        		String ilvlString = ilvl == null ? "0" : ilvl.getVal().toString();
+				String ilvlString = org.docx4j.model.listnumbering.Emulator.getIlvlOrDefault(pPr.getNumPr()).toString();
 	        		triple = null; 
 	        		if (pPr.getNumPr().getNumId()!=null) {
 		        		triple = org.docx4j.model.listnumbering.Emulator.getNumber(

--- a/docx4j-export-fo/src/main/java/org/docx4j/convert/out/fo/XsltFOFunctions.java
+++ b/docx4j-export-fo/src/main/java/org/docx4j/convert/out/fo/XsltFOFunctions.java
@@ -593,12 +593,11 @@ public class XsltFOFunctions {
 			triple = org.docx4j.model.listnumbering.Emulator.getNumber(
 					wmlPackage, pStyleVal, 
 				pPrDirect.getNumPr().getNumId().getVal().toString(), 
-				pPrDirect.getNumPr().getIlvl().getVal().toString() ); 
+				org.docx4j.model.listnumbering.Emulator.getIlvlOrDefault(pPrDirect.getNumPr()).toString() ); 
 		} else {
 			// Get the effective values; since we already know this,
 			// save the effort of doing this again in Emulator
-			Ilvl ilvl = pPr.getNumPr().getIlvl();
-			String ilvlString = ilvl == null ? "0" : ilvl.getVal().toString();
+			String ilvlString = org.docx4j.model.listnumbering.Emulator.getIlvlOrDefault(pPr.getNumPr()).toString();
 			triple = null; 
 			if (pPr.getNumPr().getNumId()!=null) {
 				triple = org.docx4j.model.listnumbering.Emulator.getNumber(


### PR DESCRIPTION
Normalize missing abstract numbering level IDs without overwriting existing levels.

Centralize paragraph numbering level resolution and default omitted or malformed values to level 0 across HTML and FO conversion paths.

Add regression tests for direct construction, malformed paragraph levels, and linked numbering styles.

<!-- Thanks for contributing to docx4j! Please see CONTRIBUTING.md. -->

## What does this PR do?

https://github.com/plutext/docx4j/issues/593

This PR improves the handling of missing or malformed numbering level values and prevents `NullPointerException`s during HTML and FO conversion.

It:

- Normalizes missing `w:lvl/@w:ilvl` values when abstract numbering definitions are loaded.
- Assigns the first available level ID without overwriting existing levels, including levels populated through linked numbering styles.
- Centralizes paragraph numbering level resolution in `Emulator`.
- Defaults omitted or malformed `w:numPr/w:ilvl` values to level `0` when the level is consumed.
- Applies the same null-safe behavior across HTML, XSLT, visitor-based, and FO conversion paths.
- Preserves nullable explicit-level handling where style resolution may still be required.
- Adds regression tests covering:
  - Direct `ListLevel` construction with a missing level ID.
  - Missing paragraph numbering levels.
  - Numbering levels with a missing `val`.
  - Allocation when level `0` is already occupied.
  - Linked numbering styles without overwriting existing levels.


## Checklist

- [x] Each commit carries a `Signed-off-by:` line added by me (DCO — see
      CONTRIBUTING.md), certifying I have the right to submit this under the
      Apache License v2.
- [x] Any AI assistance is disclosed via a commit trailer
      (`Assisted-by:` / `Generated-by:` / `Co-Authored-By:`), and I have
      personally reviewed, understood, and can explain all of the code.
- [x] Tests pass locally (`mvn test -pl docx4j-core-tests -am`), and I added
      or extended a test where practical.
- [x] `CHANGELOG.md` is updated if the change is user-visible.
